### PR TITLE
docs: add GitHub Pages deployment and clarify two-paper contributions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,13 @@ Instead of composing circuits from individual gates, SparQ operates directly on 
 - **CMake**: cmake-format + cmake-lint
 - ThirdParty code is excluded from all formatting/linting rules
 
+## Papers
+
+This repository is supported by two papers with distinct contributions:
+
+- **QRAM-Simulator** ([arXiv:2503.13832](https://arxiv.org/abs/2503.13832)): QRAM simulation, Register Level Programming paradigm, sparse state optimization, noise models, error filtration. Code: `QRAM/`, `Experiments/QRAM/`, `Experiments/ErrorFiltration/`
+- **SparQ** ([arXiv:2503.15118](https://arxiv.org/abs/2503.15118)): General-purpose sparse-state simulator, extended algorithm library (QFT, Grover, QDA, QCNN, Hamiltonian sim), PySparQ Python API, GPU acceleration. Code: `SparQ/`, `SparQ_Algorithm/`, `PySparQ/`
+
 ## GitHub Pages
 
 Doxygen documentation is auto-deployed on push to `main`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,19 @@ Instead of composing circuits from individual gates, SparQ operates directly on 
 - **CMake**: cmake-format + cmake-lint
 - ThirdParty code is excluded from all formatting/linting rules
 
+## GitHub Pages
+
+Doxygen documentation is auto-deployed on push to `main`:
+- **Landing page**: `https://iai-ustc-quantum.github.io/QRAM-Simulator/` (source: `docs/index.html`)
+- **C++ API docs**: `https://iai-ustc-quantum.github.io/QRAM-Simulator/api/` (source: Doxygen → `docs/api/html/`)
+- Deployed via `peaceiris/actions-gh-pages` to `gh-pages` branch (see `.github/workflows/cmake-multi-platform.yml`, `docs` job)
+
+## Git Workflow
+
+- `origin` → personal fork (`Agony5757/QRAM-Simulator`), active development
+- `upstream` → organization repo (`IAI-USTC-Quantum/QRAM-Simulator`), PR target
+- Changes are contributed via PR to `upstream/main`
+
 ## Dependencies
 
 All vendored in `ThirdParty/`: Eigen 3.4.0, fmt, pybind11, argparse. External requirements: OpenMP (required), CUDA 12+ (optional GPU), TBB (optional parallelization), Google Test (fetched via CMake FetchContent).

--- a/README.md
+++ b/README.md
@@ -1,10 +1,41 @@
 # QRAM-Simulator & PySparQ
 
-[![arXiv](https://img.shields.io/badge/arXiv-2503.13832-b31b1b.svg)](https://arxiv.org/abs/2503.13832)
+[![arXiv:QRAM](https://img.shields.io/badge/arXiv-QRAM_Simulator-2503.13832-b31b1b.svg)](https://arxiv.org/abs/2503.13832)
+[![arXiv:SparQ](https://img.shields.io/badge/arXiv-SparQ-2503.15118-6f42c1.svg)](https://arxiv.org/abs/2503.15118)
 [![PyPI](https://img.shields.io/pypi/v/pysparq.svg)](https://pypi.org/project/pysparq/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 > **稀疏态量子模拟器，支持 Register Level Programming**
+
+## 关联论文
+
+本仓库由两篇论文分别驱动，各自贡献了不同的核心能力：
+
+### Paper 1: QRAM-Simulator — [arXiv:2503.13832](https://arxiv.org/abs/2503.13832)
+
+> *Efficient Simulation of Quantum Random Access Memory*
+
+面向 QRAM 模拟的稀疏态量子模拟器，提出了 **Register Level Programming** 范式。主要贡献：
+
+- **QRAM 电路模拟**：Qutrit-based 与 Qubit-based 两种 QRAM 实现，支持退极化和振幅阻尼噪声模型
+- **Register Level Programming**：以 `uint64_t` 寄存器直接存储替代逐门构建，支持自顶向下的量子算法开发
+- **稀疏态优化**：仅存储非零振幅，可实现 64+ 量子比特的结构化算法模拟
+- **错误过滤**：针对含噪 QRAM 的错误过滤方案
+
+**对应代码**：`QRAM/`、`Experiments/QRAM/`、`Experiments/ErrorFiltration/`
+
+### Paper 2: SparQ — [arXiv:2503.15118](https://arxiv.org/abs/2503.15118)
+
+> *SparQ: A Sparse Quantum Circuit Simulator with Register-Level Abstraction*
+
+将 Register Level Programming 拓展为通用稀疏态量子模拟器，并提供 Python 接口。主要贡献：
+
+- **通用稀疏态模拟器**：支持 QFT、Grover、哈密顿量模拟、量子微分算法（QDA）、QCNN 等多种算法
+- **PySparQ**：通过 pybind11 提供完整 Python API，`pip install pysparq` 即可使用
+- **扩展算法库**：状态准备、块编码、量子游走、线性系统求解等高层算法
+- **GPU 加速**：CUDA 后端支持大规模并行稀疏态运算
+
+**对应代码**：`SparQ/`、`SparQ_Algorithm/`、`PySparQ/`、`Experiments/QFT/`、`Experiments/Grover/`、`Experiments/QDA/`、`Experiments/QCNN/`
 
 ## 双软件架构
 
@@ -237,11 +268,6 @@ auto result = measure(state);
 
 ## 论文与引用
 
-### 相关论文
-
-1. **QRAM-Simulator**: [arXiv:2503.13832](https://arxiv.org/abs/2503.13832)
-2. **SparQ 稀疏态模拟器**: [arXiv:2503.15118](https://arxiv.org/abs/2503.15118)
-
 ### BibTeX
 
 ```bibtex
@@ -251,6 +277,13 @@ auto result = measure(state);
   journal={arXiv preprint arXiv:2503.13832},
   year={2025}
 }
+
+@article{sparq_2025,
+  title={SparQ: A Sparse Quantum Circuit Simulator with Register-Level Abstraction},
+  author={Chen, Zhaoyun and others},
+  journal={arXiv preprint arXiv:2503.15118},
+  year={2025}
+}
 ```
 
 ### 复现论文结果
@@ -258,7 +291,7 @@ auto result = measure(state);
 详细的实验复现指南见 [docs/paper/](docs/paper/) 目录：
 
 - [docs/paper/README.md](docs/paper/README.md) - 论文关联文档
-- [docs/paper/reproduction.md](docs/paper/reproduction.md) - 实验运行详细指南
+- [docs/paper/reproduction.md](docs/paper/reproduction.md) - [QRAM-Simulator](https://arxiv.org/abs/2503.13832) 实验复现指南
 
 ## 项目结构
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,6 +13,8 @@
             --text-secondary: #8b949e;
             --accent: #58a6ff;
             --accent-hover: #79c0ff;
+            --paper1: #f0883e;
+            --paper2: #a371f7;
         }
 
         * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -59,9 +61,80 @@
             flex-wrap: wrap;
         }
 
-        .badges img {
-            height: 22px;
+        .badges img { height: 22px; }
+
+        .papers {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+            gap: 20px;
+            margin-bottom: 64px;
         }
+
+        .paper {
+            background: var(--card);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            padding: 28px;
+            border-top: 3px solid var(--border);
+            transition: border-color 0.2s, transform 0.2s;
+        }
+
+        .paper:hover {
+            transform: translateY(-2px);
+        }
+
+        .paper.paper1 { border-top-color: var(--paper1); }
+        .paper.paper2 { border-top-color: var(--paper2); }
+
+        .paper h2 {
+            font-size: 1.1rem;
+            font-weight: 600;
+            margin-bottom: 4px;
+        }
+
+        .paper .tag {
+            display: inline-block;
+            font-size: 0.75rem;
+            font-weight: 600;
+            padding: 2px 8px;
+            border-radius: 12px;
+            margin-bottom: 12px;
+        }
+
+        .paper1 .tag { background: rgba(240,136,62,0.15); color: var(--paper1); }
+        .paper2 .tag { background: rgba(163,113,247,0.15); color: var(--paper2); }
+
+        .paper p {
+            color: var(--text-secondary);
+            font-size: 0.88rem;
+            margin-bottom: 12px;
+        }
+
+        .paper ul {
+            list-style: none;
+            padding: 0;
+        }
+
+        .paper ul li {
+            color: var(--text-secondary);
+            font-size: 0.82rem;
+            padding: 3px 0;
+            padding-left: 16px;
+            position: relative;
+        }
+
+        .paper ul li::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 11px;
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+        }
+
+        .paper1 ul li::before { background: var(--paper1); }
+        .paper2 ul li::before { background: var(--paper2); }
 
         .grid {
             display: grid;
@@ -145,6 +218,11 @@
         }
 
         footer a:hover { text-decoration: underline; }
+
+        @media (max-width: 480px) {
+            .papers { grid-template-columns: 1fr; }
+            header h1 { font-size: 1.8rem; }
+        }
     </style>
 </head>
 <body>
@@ -153,11 +231,37 @@
             <h1>QRAM-Simulator</h1>
             <p>Sparse-state quantum circuit simulator with native QRAM support and Register Level Programming</p>
             <div class="badges">
-                <img src="https://img.shields.io/badge/arXiv-2503.13832-b31b1b.svg" alt="arXiv">
+                <a href="https://arxiv.org/abs/2503.13832"><img src="https://img.shields.io/badge/arXiv-QRAM_Simulator-2503.13832-b31b1b.svg" alt="arXiv: QRAM-Simulator"></a>
+                <a href="https://arxiv.org/abs/2503.15118"><img src="https://img.shields.io/badge/arXiv-SparQ-2503.15118-6f42c1.svg" alt="arXiv: SparQ"></a>
                 <img src="https://img.shields.io/pypi/v/pysparq.svg" alt="PyPI">
                 <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License">
             </div>
         </header>
+
+        <div class="papers">
+            <div class="paper paper1">
+                <h2>QRAM-Simulator</h2>
+                <span class="tag">arXiv:2503.13832</span>
+                <p>Efficient Simulation of Quantum Random Access Memory</p>
+                <ul>
+                    <li>QRAM circuit simulation (Qutrit &amp; Qubit)</li>
+                    <li>Register Level Programming paradigm</li>
+                    <li>Sparse state optimization (64+ qubits)</li>
+                    <li>Noise models &amp; error filtration</li>
+                </ul>
+            </div>
+            <div class="paper paper2">
+                <h2>SparQ</h2>
+                <span class="tag">arXiv:2503.15118</span>
+                <p>A Sparse Quantum Circuit Simulator with Register-Level Abstraction</p>
+                <ul>
+                    <li>General-purpose sparse-state simulator</li>
+                    <li>QFT, Grover, QDA, QCNN, Hamiltonian sim</li>
+                    <li>PySparQ Python API (<code>pip install pysparq</code>)</li>
+                    <li>CUDA GPU acceleration</li>
+                </ul>
+            </div>
+        </div>
 
         <div class="grid">
             <a class="card" href="api/index.html">

--- a/docs/paper/README.md
+++ b/docs/paper/README.md
@@ -2,48 +2,50 @@
 
 本目录包含与论文相关的文档和复现指南。
 
-## 关联论文
+## Paper 1: QRAM-Simulator — [arXiv:2503.13832](https://arxiv.org/abs/2503.13832)
 
-- **QRAM-Simulator**: [arXiv:2503.13832](https://arxiv.org/abs/2503.13832) - Efficient Simulation of Quantum Random Access Memory
-- **SparQ**: [arXiv:2503.15118](https://arxiv.org/abs/2503.15118) - SparQ: A Sparse Quantum Circuit Simulator with Register-Level Abstraction
+> *Efficient Simulation of Quantum Random Access Memory*
 
-## 文件说明
+提出稀疏态 QRAM 模拟器和 Register Level Programming 范式。
 
-| 文件 | 说明 |
-|------|------|
-| [reproduction.md](reproduction.md) | 详细的实验复现步骤和命令 |
-| README.md | 本文档 |
+**核心贡献**：QRAM 电路模拟（Qutrit/Qubit）、噪声模型、稀疏态优化、错误过滤方案
 
-## 实验代码位置
-
-论文中的数值结果由以下代码生成：
+**实验代码**：
 
 | 实验 | 代码路径 | CMake Target |
 |------|----------|--------------|
-| QRAM 保真度实验（主模拟 + 性能分析） | `Experiments/QRAM/QRAMFidelity/QRAMFidelityTest.cpp` | `Experiment_QRAM_Fidelity` |
-| QRAM 模拟器对比（完整版 vs 简化版） | `Experiments/QRAM/QRAMFidelityV2/QRAMSimulatorTest.cpp` | `Experiment_QRAM_FidelityV2` |
+| QRAM 保真度实验 | `Experiments/QRAM/QRAMFidelity/QRAMFidelityTest.cpp` | `Experiment_QRAM_Fidelity` |
+| QRAM 模拟器对比 | `Experiments/QRAM/QRAMFidelityV2/QRAMSimulatorTest.cpp` | `Experiment_QRAM_FidelityV2` |
 | 错误过滤实验 | `Experiments/ErrorFiltration/testMultiEFQRAM.cpp` | `Experiment_ErrorFiltration` |
 
-## 快速复现
+**复现指南**：[reproduction.md](reproduction.md)
+
+## Paper 2: SparQ — [arXiv:2503.15118](https://arxiv.org/abs/2503.15118)
+
+> *SparQ: A Sparse Quantum Circuit Simulator with Register-Level Abstraction*
+
+将 Register Level Programming 拓展为通用稀疏态模拟器，并提供 Python 接口 (PySparQ)。
+
+**核心贡献**：通用稀疏态模拟器、扩展算法库（QFT、Grover、QDA、QCNN 等）、PySparQ Python API、GPU 加速
+
+**实验代码**：
+
+| 实验 | 代码路径 |
+|------|----------|
+| QFT | `Experiments/QFT/` |
+| Grover | `Experiments/Grover/` |
+| 状态准备 | `Experiments/StatePreparation/` |
+| 量子微分算法 | `Experiments/QDA/` |
+| QCNN | `Experiments/QCNN/` |
+| 线性系统求解 | `Experiments/CKS/` |
+
+## 快速复现（Paper 1）
 
 ```bash
-# 1. 构建实验
 mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
 make Experiment_QRAM_Fidelity Experiment_QRAM_FidelityV2 Experiment_ErrorFiltration
 
-# 2. 运行实验（示例）
 ./bin/Experiment_QRAM_Fidelity --addrsize 15 --datasize 3 --shots 100 --inputsize 10 \
     --depolarizing 1e-4 --damping 1e-5 --seed 123456 --version normal
 ```
-
-详细的参数说明和完整复现流程请参考 [reproduction.md](reproduction.md)。
-
-## 结果说明
-
-实验输出包含：
-- 保真度随地址位数、噪声参数的 scaling 数据
-- 不同 QRAM 架构的性能对比
-- 错误过滤方案的效果评估
-
-原始实验数据已随论文提供。基于这些输出，可以使用标准的数据分析脚本进行绘图和制表。


### PR DESCRIPTION
## Summary

- **GitHub Pages**: Add Doxygen docs auto-deployment to `gh-pages` branch via CI (`peaceiris/actions-gh-pages`), with a custom landing page at root and API docs under `/api/`
- **Two-paper distinction**: Update README, `docs/paper/README.md`, and landing page to clearly separate contributions from QRAM-Simulator (arXiv:2503.13832) and SparQ (arXiv:2503.15118)
- **CLAUDE.md**: Add GitHub Pages info, git workflow, and papers section

## Access

- Landing page: `https://iai-ustc-quantum.github.io/QRAM-Simulator/`
- API docs: `https://iai-ustc-quantum.github.io/QRAM-Simulator/api/`

## Post-merge

Ensure GitHub Pages Source is set to **gh-pages / (root)** in repo settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)