### PR TITLE
fix: remove CI path filters and reorganize README paper section

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -3,28 +3,8 @@ name: CMake on multiple platforms
 on:
   push:
     branches: [ "main", "develop" ]
-    paths:
-      - 'CMakeLists.txt'
-      - '**/*.cmake'
-      - '**/*.h'
-      - '**/*.hpp'
-      - '**/*.cpp'
-      - '**/*.cu'
-      - '**/*.py'
-      - 'ThirdParty/**'
-      - '.github/workflows/cmake-multi-platform.yml'
   pull_request:
     branches: [ "main", "develop" ]
-    paths:
-      - 'CMakeLists.txt'
-      - '**/*.cmake'
-      - '**/*.h'
-      - '**/*.hpp'
-      - '**/*.cpp'
-      - '**/*.cu'
-      - '**/*.py'
-      - 'ThirdParty/**'
-      - '.github/workflows/cmake-multi-platform.yml'
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -7,36 +7,6 @@
 
 > **稀疏态量子模拟器，支持 Register Level Programming**
 
-## 关联论文
-
-本仓库由两篇论文分别驱动，各自贡献了不同的核心能力：
-
-### Paper 1: QRAM-Simulator — [arXiv:2503.13832](https://arxiv.org/abs/2503.13832)
-
-> *Efficient Simulation of Quantum Random Access Memory*
-
-面向 QRAM 模拟的稀疏态量子模拟器，提出了 **Register Level Programming** 范式。主要贡献：
-
-- **QRAM 电路模拟**：Qutrit-based 与 Qubit-based 两种 QRAM 实现，支持退极化和振幅阻尼噪声模型
-- **Register Level Programming**：以 `uint64_t` 寄存器直接存储替代逐门构建，支持自顶向下的量子算法开发
-- **稀疏态优化**：仅存储非零振幅，可实现 64+ 量子比特的结构化算法模拟
-- **错误过滤**：针对含噪 QRAM 的错误过滤方案
-
-**对应代码**：`QRAM/`、`Experiments/QRAM/`、`Experiments/ErrorFiltration/`
-
-### Paper 2: SparQ — [arXiv:2503.15118](https://arxiv.org/abs/2503.15118)
-
-> *SparQ: A Sparse Quantum Circuit Simulator with Register-Level Abstraction*
-
-将 Register Level Programming 拓展为通用稀疏态量子模拟器，并提供 Python 接口。主要贡献：
-
-- **通用稀疏态模拟器**：支持 QFT、Grover、哈密顿量模拟、量子微分算法（QDA）、QCNN 等多种算法
-- **PySparQ**：通过 pybind11 提供完整 Python API，`pip install pysparq` 即可使用
-- **扩展算法库**：状态准备、块编码、量子游走、线性系统求解等高层算法
-- **GPU 加速**：CUDA 后端支持大规模并行稀疏态运算
-
-**对应代码**：`SparQ/`、`SparQ_Algorithm/`、`PySparQ/`、`Experiments/QFT/`、`Experiments/Grover/`、`Experiments/QDA/`、`Experiments/QCNN/`
-
 ## 双软件架构
 
 本仓库包含两个紧密协作的软件组件，面向不同的用户群体和使用场景：
@@ -267,6 +237,34 @@ auto result = measure(state);
 ```
 
 ## 论文与引用
+
+本仓库由两篇论文分别驱动，各自贡献了不同的核心能力：
+
+### Paper 1: QRAM-Simulator — [arXiv:2503.13832](https://arxiv.org/abs/2503.13832)
+
+> *Efficient Simulation of Quantum Random Access Memory*
+
+面向 QRAM 模拟的稀疏态量子模拟器，提出了 **Register Level Programming** 范式。主要贡献：
+
+- **QRAM 电路模拟**：Qutrit-based 与 Qubit-based 两种 QRAM 实现，支持退极化和振幅阻尼噪声模型
+- **Register Level Programming**：以 `uint64_t` 寄存器直接存储替代逐门构建，支持自顶向下的量子算法开发
+- **稀疏态优化**：仅存储非零振幅，可实现 64+ 量子比特的结构化算法模拟
+- **错误过滤**：针对含噪 QRAM 的错误过滤方案
+
+**对应代码**：`QRAM/`、`Experiments/QRAM/`、`Experiments/ErrorFiltration/`
+
+### Paper 2: SparQ — [arXiv:2503.15118](https://arxiv.org/abs/2503.15118)
+
+> *SparQ: A Sparse Quantum Circuit Simulator with Register-Level Abstraction*
+
+将 Register Level Programming 拓展为通用稀疏态量子模拟器，并提供 Python 接口。主要贡献：
+
+- **通用稀疏态模拟器**：支持 QFT、Grover、哈密顿量模拟、量子微分算法（QDA）、QCNN 等多种算法
+- **PySparQ**：通过 pybind11 提供完整 Python API，`pip install pysparq` 即可使用
+- **扩展算法库**：状态准备、块编码、量子游走、线性系统求解等高层算法
+- **GPU 加速**：CUDA 后端支持大规模并行稀疏态运算
+
+**对应代码**：`SparQ/`、`SparQ_Algorithm/`、`PySparQ/`、`Experiments/QFT/`、`Experiments/Grover/`、`Experiments/QDA/`、`Experiments/QCNN/`
 
 ### BibTeX
 


### PR DESCRIPTION
## Summary

- **CI trigger fix**: Remove `paths` filters from workflow so doc-only changes (README, HTML, Doxyfile) also trigger builds and deploy GitHub Pages
- **README restructure**: Move "关联论文" from the top to the existing "论文与引用" section at the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)