### PR TITLE
fix: correct arXiv badge URL format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # QRAM-Simulator & PySparQ
 
-[![arXiv:QRAM](https://img.shields.io/badge/arXiv-QRAM_Simulator-2503.13832-b31b1b.svg)](https://arxiv.org/abs/2503.13832)
-[![arXiv:SparQ](https://img.shields.io/badge/arXiv-SparQ-2503.15118-6f42c1.svg)](https://arxiv.org/abs/2503.15118)
+[![arXiv:QRAM](https://img.shields.io/badge/QRAM_Simulator-arXiv%3A2503%2E13832-b31b1b.svg)](https://arxiv.org/abs/2503.13832)
+[![arXiv:SparQ](https://img.shields.io/badge/SparQ-arXiv%3A2503%2E15118-6f42c1.svg)](https://arxiv.org/abs/2503.15118)
 [![PyPI](https://img.shields.io/pypi/v/pysparq.svg)](https://pypi.org/project/pysparq/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -231,8 +231,8 @@
             <h1>QRAM-Simulator</h1>
             <p>Sparse-state quantum circuit simulator with native QRAM support and Register Level Programming</p>
             <div class="badges">
-                <a href="https://arxiv.org/abs/2503.13832"><img src="https://img.shields.io/badge/arXiv-QRAM_Simulator-2503.13832-b31b1b.svg" alt="arXiv: QRAM-Simulator"></a>
-                <a href="https://arxiv.org/abs/2503.15118"><img src="https://img.shields.io/badge/arXiv-SparQ-2503.15118-6f42c1.svg" alt="arXiv: SparQ"></a>
+                <a href="https://arxiv.org/abs/2503.13832"><img src="https://img.shields.io/badge/QRAM_Simulator-arXiv%3A2503%2E13832-b31b1b.svg" alt="arXiv: QRAM-Simulator"></a>
+                <a href="https://arxiv.org/abs/2503.15118"><img src="https://img.shields.io/badge/SparQ-arXiv%3A2503%2E15118-6f42c1.svg" alt="arXiv: SparQ"></a>
                 <img src="https://img.shields.io/pypi/v/pysparq.svg" alt="PyPI">
                 <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License">
             </div>


### PR DESCRIPTION
## Summary

- Fix shields.io badge URLs returning 404 by properly URL-encoding dots (`.` → `%2E`) and colons (`:` → `%3A`) in the message field

🤖 Generated with [Claude Code](https://claude.com/claude-code)