### PR TITLE
fix: resolve pyproject.toml build error and update git workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,9 +83,34 @@ Doxygen documentation is auto-deployed on push to `main`:
 
 ## Git Workflow
 
-- `origin` → personal fork (`Agony5757/QRAM-Simulator`), active development
-- `upstream` → organization repo (`IAI-USTC-Quantum/QRAM-Simulator`), PR target
-- Changes are contributed via PR to `upstream/main`
+**IMPORTANT: Never push directly to `origin/main`. Always work on fork and submit PRs.**
+
+Remote configuration:
+- `origin` → upstream organization repo (`IAI-USTC-Quantum/QRAM-Simulator`)
+- `fork` → personal fork (`Agony5757/QRAM-Simulator`)
+
+Workflow:
+1. All development happens on `fork` (personal fork)
+2. Changes are submitted via PR from `fork` to `origin/main`
+3. Never push directly to `origin` - it should be protected
+
+Typical workflow:
+```bash
+# Create feature branch on fork
+git checkout -b feature/my-feature fork/main
+
+# Push to fork
+git push fork feature/my-feature
+
+# Create PR to origin/main
+gh pr create --repo IAI-USTC-Quantum/QRAM-Simulator --head Agony5757:feature/my-feature
+```
+
+Sync fork with upstream:
+```bash
+gh repo sync Agony5757/QRAM-Simulator --source IAI-USTC-Quantum/QRAM-Simulator --branch main
+git fetch fork
+```
 
 ## Dependencies
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,6 @@ cmake.build-type = "Release"
 wheel.packages = ["PySparQ/pysparq"]
 ninja.make-fallback = false
 
-# Include PEP 561 type marker file
-[[tool.scikit-build.wheel.include]]
-path = "PySparQ/pysparq/py.typed"
-destination = "pysparq/py.typed"
-
 
 [tool.cibuildwheel]
 build-frontend = "build[uv]"


### PR DESCRIPTION
## Summary

- Fix invalid `tool.scikit-build.wheel.include` config that caused Python package build failure
- `py.typed` is automatically included via `wheel.packages` configuration
- Update `CLAUDE.md` with correct git workflow instructions (never push directly to `origin/main`)

## Problem

The previous commit (`7af984b`) incorrectly added `[[tool.scikit-build.wheel.include]]` which is not supported by scikit-build-core, causing CI failure:

```
ERROR: Unrecognized options in pyproject.toml:
  tool.scikit-build.wheel.include
```

## Test Plan

- [x] Verified scikit-build-core documentation - `wheel.packages` already includes the pysparq directory
- [x] py.typed file will be included automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)