### PR TITLE
fix: add .pyi stub files for algorithms module to enable autodoc

### DIFF
--- a/PySparQ/pysparq/algorithms/__init__.pyi
+++ b/PySparQ/pysparq/algorithms/__init__.pyi
@@ -1,0 +1,9 @@
+"""
+PySparQ Algorithm Examples
+
+This package contains educational implementations of quantum algorithms
+using PySparQ's Register Level Programming paradigm.
+"""
+
+__all__: list[str]
+__version__: str

--- a/PySparQ/pysparq/algorithms/cks_solver.pyi
+++ b/PySparQ/pysparq/algorithms/cks_solver.pyi
@@ -1,0 +1,260 @@
+"""
+CKS (Childs-Kothari-Somma) Linear System Solver Implementation
+"""
+
+from dataclasses import dataclass
+from typing import Callable, List, Optional
+
+import numpy as np
+import pysparq as ps
+
+
+class ChebyshevPolynomialCoefficient:
+    """Computes Chebyshev polynomial coefficients for quantum walk."""
+
+    b: int
+
+    def __init__(self, b: int) -> None: ...
+    def C(self, Big: int, Small: int) -> float: ...
+    def coef(self, j: int) -> float: ...
+    def sign(self, j: int) -> bool: ...
+    def step(self, j: int) -> int: ...
+
+
+def get_coef_positive_only(
+    mat_data_size: int, v: int, row: int, col: int
+) -> List[complex]:
+    """Get rotation matrix coefficients for positive-only matrix elements."""
+    ...
+
+
+def get_coef_common(
+    mat_data_size: int, v: int, row: int, col: int
+) -> List[complex]:
+    """Get rotation matrix coefficients for general (signed) matrix elements."""
+    ...
+
+
+def make_walk_angle_func(
+    mat_data_size: int, positive_only: bool
+) -> Callable[[int, int, int], List[complex]]:
+    """Create walk angle function for a matrix."""
+    ...
+
+
+@dataclass
+class SparseMatrixData:
+    """Sparse matrix data for quantum simulation."""
+
+    n_row: int
+    nnz_col: int
+    data: List[int]
+    data_size: int
+    positive_only: bool
+    sparsity_offset: int
+
+
+class SparseMatrix:
+    """Sparse matrix representation for CKS algorithm."""
+
+    n_row: int
+    nnz_col: int
+    data: List[int]
+    data_size: int
+    positive_only: bool
+    sparsity_offset: int
+
+    def __init__(
+        self,
+        n_row: int,
+        nnz_col: int,
+        data: List[int],
+        data_size: int,
+        positive_only: bool = ...,
+    ) -> None: ...
+    @classmethod
+    def from_dense(
+        cls,
+        matrix: np.ndarray,
+        data_size: int = ...,
+        positive_only: Optional[bool] = ...,
+    ) -> "SparseMatrix": ...
+    def get_data(self) -> List[int]: ...
+    def get_sparsity_offset(self) -> int: ...
+    def get_walk_angle_func(self) -> Callable[[int, int, int], List[complex]]: ...
+
+
+class QuantumBinarySearch:
+    """Quantum binary search for sparse matrix access."""
+
+    qram: ps.QRAMCircuit_qutrit
+    address_offset_reg: str
+    total_length: int
+    target_reg: str
+    result_reg: str
+    max_step: int
+
+    def __init__(
+        self,
+        qram: ps.QRAMCircuit_qutrit,
+        address_offset_reg: str,
+        total_length: int,
+        target_reg: str,
+        result_reg: str,
+    ) -> None: ...
+    def __call__(self, state: ps.SparseState) -> None: ...
+
+
+class CondRotQW:
+    """Conditional rotation for quantum walk."""
+
+    j_reg: str
+    k_reg: str
+    data_reg: str
+    output_reg: str
+    mat: SparseMatrix
+
+    def __init__(
+        self,
+        j_reg: str,
+        k_reg: str,
+        data_reg: str,
+        output_reg: str,
+        mat: SparseMatrix,
+    ) -> None: ...
+    def __call__(self, state: ps.SparseState) -> None: ...
+    def dag(self, state: ps.SparseState) -> None: ...
+
+
+class TOperator:
+    """T operator for CKS algorithm."""
+
+    qram: ps.QRAMCircuit_qutrit
+    data_offset_reg: str
+    sparse_offset_reg: str
+    j_reg: str
+    b1_reg: str
+    k_reg: str
+    b2_reg: str
+    search_result_reg: str
+    nnz_col: int
+    data_size: int
+    mat: SparseMatrix
+
+    def __init__(
+        self,
+        qram: ps.QRAMCircuit_qutrit,
+        data_offset_reg: str,
+        sparse_offset_reg: str,
+        j_reg: str,
+        b1_reg: str,
+        k_reg: str,
+        b2_reg: str,
+        search_result_reg: str,
+        nnz_col: int,
+        data_size: int,
+        mat: SparseMatrix,
+    ) -> None: ...
+    def __call__(self, state: ps.SparseState) -> None: ...
+    def dag(self, state: ps.SparseState) -> None: ...
+
+
+class QuantumWalk:
+    """Quantum walk operator for CKS algorithm."""
+
+    qram: ps.QRAMCircuit_qutrit
+    j_reg: str
+    b1_reg: str
+    k_reg: str
+    b2_reg: str
+    j_comp_reg: str
+    k_comp_reg: str
+    data_offset_reg: str
+    sparse_offset_reg: str
+    mat: SparseMatrix
+
+    def __init__(
+        self,
+        qram: ps.QRAMCircuit_qutrit,
+        j_reg: str,
+        b1_reg: str,
+        k_reg: str,
+        b2_reg: str,
+        j_comp_reg: str,
+        k_comp_reg: str,
+        data_offset_reg: str,
+        sparse_offset_reg: str,
+        mat: SparseMatrix,
+    ) -> None: ...
+    def __call__(self, state: ps.SparseState) -> None: ...
+    def dag(self, state: ps.SparseState) -> None: ...
+
+
+class QuantumWalkNSteps:
+    """Multiple quantum walk steps for CKS algorithm."""
+
+    mat: SparseMatrix
+    qram: ps.QRAMCircuit_qutrit
+    addr_size: int
+    data_size: int
+    nnz_col: int
+    n_row: int
+    default_reg_size: int
+    data_offset: str
+    sparse_offset: str
+    j: str
+    b1: str
+    k: str
+    b2: str
+    j_comp: str
+    k_comp: str
+
+    def __init__(
+        self, mat: SparseMatrix, qram: Optional[ps.QRAMCircuit_qutrit] = ...
+    ) -> None: ...
+    def init_environment(self) -> None: ...
+    def create_state(self) -> ps.SparseState: ...
+    def first_step(self, state: ps.SparseState) -> None: ...
+    def step(self, state: ps.SparseState) -> None: ...
+    def make_n_step_state(self, n_steps: int) -> ps.SparseState: ...
+
+
+class LCUContainer:
+    """LCU (Linear Combination of Unitaries) container for CKS."""
+
+    kappa: float
+    eps: float
+    b: int
+    j0: int
+    chebyshev: ChebyshevPolynomialCoefficient
+    walk: QuantumWalkNSteps
+    current_state: Optional[ps.SparseState]
+    step_state: Optional[ps.SparseState]
+
+    def __init__(
+        self,
+        mat: SparseMatrix,
+        kappa: float,
+        eps: float,
+        qram: Optional[ps.QRAMCircuit_qutrit] = ...,
+    ) -> None: ...
+    def get_input_reg(self) -> str: ...
+    def initialize(self) -> None: ...
+    def external_input(self, init_op: Callable[[ps.SparseState], None]) -> None: ...
+    def iterate(self) -> bool: ...
+
+
+def cks_solve(
+    A: np.ndarray,
+    b: np.ndarray,
+    kappa: Optional[float] = ...,
+    eps: float = ...,
+    data_size: int = ...,
+) -> np.ndarray:
+    """Solve Ax = b using CKS quantum linear solver."""
+    ...
+
+
+def create_cks_demo() -> str:
+    """Generate a demo script for CKS solver."""
+    ...

--- a/PySparQ/pysparq/algorithms/grover.pyi
+++ b/PySparQ/pysparq/algorithms/grover.pyi
@@ -1,0 +1,86 @@
+"""
+Grover's Quantum Search Algorithm Implementation
+"""
+
+from typing import List, Optional, Tuple, Union
+
+import pysparq as ps
+
+
+class GroverOracle:
+    """Oracle for Grover's search that marks target values."""
+
+    qram: ps.QRAMCircuit_qutrit
+    addr_reg: Union[str, int]
+    data_reg: Union[str, int]
+    search_reg: Union[str, int]
+
+    def __init__(
+        self,
+        qram: ps.QRAMCircuit_qutrit,
+        addr_reg: Union[str, int],
+        data_reg: Union[str, int],
+        search_reg: Union[str, int],
+    ) -> None: ...
+    def conditioned_by_nonzeros(
+        self, cond: Union[str, int, List[Union[str, int]]]
+    ) -> "GroverOracle": ...
+    def clear_conditions(self) -> None: ...
+    def __call__(self, state: ps.SparseState) -> None: ...
+
+
+class DiffusionOperator:
+    """HPH (Hadamard-Phase-Hadamard) diffusion operator."""
+
+    addr_reg: Union[str, int]
+
+    def __init__(self, addr_reg: Union[str, int]) -> None: ...
+    def conditioned_by_nonzeros(
+        self, cond: Union[str, int, List[Union[str, int]]]
+    ) -> "DiffusionOperator": ...
+    def clear_conditions(self) -> None: ...
+    def __call__(self, state: ps.SparseState) -> None: ...
+
+
+class GroverOperator:
+    """Combined Grover operator: Oracle followed by Diffusion."""
+
+    oracle: GroverOracle
+    diffusion: DiffusionOperator
+
+    def __init__(
+        self,
+        qram: ps.QRAMCircuit_qutrit,
+        addr_reg: Union[str, int],
+        data_reg: Union[str, int],
+        search_reg: Union[str, int],
+    ) -> None: ...
+    def conditioned_by_nonzeros(
+        self, cond: Union[str, int, List[Union[str, int]]]
+    ) -> "GroverOperator": ...
+    def __call__(self, state: ps.SparseState) -> None: ...
+
+
+def grover_search(
+    memory: List[int],
+    target: int,
+    n_iterations: Optional[int] = ...,
+    data_size: int = ...,
+) -> Tuple[int, float]:
+    """Execute Grover's search to find target in memory."""
+    ...
+
+
+def grover_count(
+    memory: List[int],
+    target: int,
+    precision_bits: int = ...,
+    data_size: int = ...,
+) -> Tuple[int, float]:
+    """Quantum counting variant of Grover's algorithm."""
+    ...
+
+
+def create_grover_demo() -> str:
+    """Generate a demo script for Grover's algorithm."""
+    ...

--- a/PySparQ/pysparq/algorithms/qda_solver.pyi
+++ b/PySparQ/pysparq/algorithms/qda_solver.pyi
@@ -1,0 +1,227 @@
+"""
+QDA (Quantum Discrete Adiabatic) Linear System Solver Implementation
+"""
+
+from dataclasses import dataclass
+from typing import Callable, List, Optional, Tuple, Union
+
+import numpy as np
+import pysparq as ps
+
+
+def compute_fs(s: float, kappa: float, p: float) -> float:
+    """Compute the interpolation parameter f(s)."""
+    ...
+
+
+def compute_rotation_matrix(fs: float) -> List[complex]:
+    """Compute the rotation matrix R_s for block encoding."""
+    ...
+
+
+def chebyshev_T(n: int, x: float) -> float:
+    """Compute Chebyshev polynomial T_n(x)."""
+    ...
+
+
+def dolph_chebyshev(epsilon: float, l: int, phi: float) -> float:
+    """Compute Dolph-Chebyshev window function."""
+    ...
+
+
+def compute_fourier_coeffs(epsilon: float, l: int) -> List[float]:
+    """Compute Fourier coefficients for Dolph-Chebyshev filter."""
+    ...
+
+
+def calculate_angles(coeffs: List[float]) -> List[float]:
+    """Calculate rotation angles from coefficients for state preparation."""
+    ...
+
+
+class BlockEncoding:
+    """Placeholder for block encoding implementation."""
+
+    A: np.ndarray
+    data_size: int
+
+    def __init__(self, A: np.ndarray, data_size: int = ...) -> None: ...
+    def conditioned_by_all_ones(
+        self, conds: Union[str, List[str]]
+    ) -> "BlockEncoding": ...
+    def __call__(self, state: ps.SparseState) -> None: ...
+    def dag(self, state: ps.SparseState) -> None: ...
+
+
+class StatePreparation:
+    """Placeholder for state preparation implementation."""
+
+    b: np.ndarray
+
+    def __init__(self, b: np.ndarray) -> None: ...
+    def conditioned_by_all_ones(
+        self, conds: Union[str, List[str]]
+    ) -> "StatePreparation": ...
+    def __call__(self, state: ps.SparseState) -> None: ...
+    def dag(self, state: ps.SparseState) -> None: ...
+
+
+class BlockEncodingHs:
+    """Block encoding of the interpolating Hamiltonian H(s)."""
+
+    enc_A: BlockEncoding
+    enc_b: StatePreparation
+    main_reg: str
+    anc_UA: str
+    anc_1: str
+    anc_2: str
+    anc_3: str
+    anc_4: str
+    fs: float
+    R_s: List[complex]
+
+    def __init__(
+        self,
+        enc_A: BlockEncoding,
+        enc_b: StatePreparation,
+        main_reg: str,
+        anc_UA: str,
+        anc_1: str,
+        anc_2: str,
+        anc_3: str,
+        anc_4: str,
+        fs: float,
+    ) -> None: ...
+    def conditioned_by_all_ones(
+        self, conds: Union[str, List[str]]
+    ) -> "BlockEncodingHs": ...
+    def __call__(self, state: ps.SparseState) -> None: ...
+    def dag(self, state: ps.SparseState) -> None: ...
+
+
+class BlockEncodingHsPD:
+    """Positive-definite version of block encoding H(s)."""
+
+    enc_A: BlockEncoding
+    enc_b: StatePreparation
+    main_reg: str
+    anc_UA: str
+    anc_1: str
+    anc_2: str
+    anc_3: str
+    anc_4: str
+    fs: float
+    R_s: List[complex]
+
+    def __init__(
+        self,
+        enc_A: BlockEncoding,
+        enc_b: StatePreparation,
+        main_reg: str,
+        anc_UA: str,
+        anc_1: str,
+        anc_2: str,
+        anc_3: str,
+        anc_4: str,
+        fs: float,
+    ) -> None: ...
+    def __call__(self, state: ps.SparseState) -> None: ...
+
+
+class WalkS:
+    """Quantum walk operator at parameter s."""
+
+    main_reg: str
+    anc_UA: str
+    anc_1: str
+    anc_2: str
+    anc_3: str
+    anc_4: str
+    s: float
+    kappa: float
+    p: float
+    is_positive_definite: bool
+    fs: float
+    phase: complex
+    enc_Hs: BlockEncodingHs
+
+    def __init__(
+        self,
+        enc_A: BlockEncoding,
+        enc_b: StatePreparation,
+        main_reg: str,
+        anc_UA: str,
+        anc_1: str,
+        anc_2: str,
+        anc_3: str,
+        anc_4: str,
+        s: float,
+        kappa: float,
+        p: float,
+        is_positive_definite: bool = ...,
+    ) -> None: ...
+    def conditioned_by_all_ones(
+        self, conds: Union[str, List[str]]
+    ) -> "WalkS": ...
+    def conditioned_by_bit(self, reg: str, pos: int) -> "WalkS": ...
+    def clear_control_by_bit(self) -> None: ...
+    def __call__(self, state: ps.SparseState) -> None: ...
+    def dag(self, state: ps.SparseState) -> None: ...
+
+
+class LCU:
+    """Linear Combination of Unitaries for QDA."""
+
+    walk: WalkS
+    index_reg: str
+    log_file: str
+    index_size: int
+
+    def __init__(self, walk: WalkS, index_reg: str, log_file: str = ...) -> None: ...
+    def __call__(self, state: ps.SparseState) -> None: ...
+    def dag(self, state: ps.SparseState) -> None: ...
+
+
+class Filtering:
+    """Dolph-Chebyshev filtering for QDA."""
+
+    walk: WalkS
+    index_reg: str
+    anc_h: str
+    epsilon: float
+    l: int
+    coeffs: List[float]
+
+    def __init__(
+        self,
+        walk: WalkS,
+        index_reg: str,
+        anc_h: str,
+        epsilon: float = ...,
+        l: int = ...,
+    ) -> None: ...
+    def __call__(self, state: ps.SparseState) -> float: ...
+
+
+def classical_to_quantum(
+    A: np.ndarray, b: np.ndarray
+) -> Tuple[np.ndarray, np.ndarray, Callable[[np.ndarray], np.ndarray]]:
+    """Convert classical linear system to quantum-compatible form."""
+    ...
+
+
+def qda_solve(
+    A: np.ndarray,
+    b: np.ndarray,
+    kappa: Optional[float] = ...,
+    p: float = ...,
+    eps: float = ...,
+    step_rate: float = ...,
+) -> np.ndarray:
+    """Solve Ax = b using QDA algorithm."""
+    ...
+
+
+def create_qda_demo() -> str:
+    """Generate a demo script for QDA solver."""
+    ...

--- a/PySparQ/pysparq/algorithms/shor.pyi
+++ b/PySparQ/pysparq/algorithms/shor.pyi
@@ -1,0 +1,116 @@
+"""
+Shor's Quantum Factorization Algorithm Implementation
+"""
+
+from typing import List, Optional, Tuple
+
+import pysparq as ps
+
+
+class ShorExecutionFailed(Exception):
+    """Exception raised when Shor's algorithm fails to find factors."""
+    ...
+
+
+def general_expmod(a: int, x: int, N: int) -> int:
+    """Compute a^x mod N efficiently using square-and-multiply."""
+    ...
+
+
+def find_best_fraction(y: int, Q: int, N: int) -> Tuple[int, int]:
+    """Find the best fraction c/r approximating y/Q using Farey sequence."""
+    ...
+
+
+def compute_period(meas_result: int, size: int, N: int) -> int:
+    """Compute the period from measurement result."""
+    ...
+
+
+def check_period(period: int, a: int, N: int) -> None:
+    """Check if period is valid for factoring."""
+    ...
+
+
+def shor_postprocess(meas: int, size: int, a: int, N: int) -> Tuple[int, int]:
+    """Classical post-processing for Shor's algorithm."""
+    ...
+
+
+class ModMul:
+    """Controlled modular multiplication operation."""
+
+    reg: str
+    a: int
+    x: int
+    N: int
+    opnum: int
+
+    def __init__(self, reg: str, a: int, x: int, N: int) -> None: ...
+    def conditioned_by_all_ones(self, cond: str) -> "ModMul": ...
+    def __call__(self, state: ps.SparseState) -> None: ...
+
+
+class SemiClassicalShor:
+    """Semi-classical implementation of Shor's algorithm."""
+
+    a: int
+    N: int
+    n: int
+    size: int
+    meas_result: int
+    period: int
+    p: int
+    q: int
+
+    def __init__(self, a: int, N: int) -> None: ...
+    def run(self) -> Tuple[int, int]: ...
+
+
+class ExpMod:
+    """Modular exponentiation operation."""
+
+    input_reg: str
+    output_reg: str
+    a: int
+    N: int
+    period: int
+
+    def __init__(
+        self, input_reg: str, output_reg: str, a: int, N: int, period: int
+    ) -> None: ...
+    def __call__(self, state: ps.SparseState) -> None: ...
+    def dag(self, state: ps.SparseState) -> None: ...
+
+
+class Shor:
+    """Full quantum Shor's algorithm."""
+
+    work_reg: str
+    ancilla_reg: str
+    expmod: ExpMod
+
+    def __init__(
+        self,
+        work_reg: str,
+        ancilla_reg: str,
+        a: int,
+        N: int,
+        period: int,
+    ) -> None: ...
+    def __call__(self, state: ps.SparseState) -> None: ...
+
+
+def factor(N: int, a: Optional[int] = ...) -> Tuple[int, int]:
+    """Factor N using Shor's algorithm."""
+    ...
+
+
+def factor_full_quantum(N: int, a: Optional[int] = ...) -> Tuple[int, int]:
+    """Factor N using full quantum Shor's algorithm."""
+    ...
+
+
+def create_shor_demo() -> str:
+    """Generate a demo script for Shor's algorithm."""
+    ...

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -87,7 +87,7 @@ myst_enable_extensions = [
 
 autoapi_type = "python"
 autoapi_dirs = ["../../../PySparQ/pysparq"]
-autoapi_file_patterns = ["*.pyi"]
+autoapi_file_patterns = ["*.pyi", "*.py"]
 autoapi_generate_api_docs = True
 autoapi_add_toctree_entry = False
 autoapi_options = [


### PR DESCRIPTION
## Summary

修复算法文档中 API Reference 部分为空的问题。

## Problem

算法文档页面（如 grover.rst）的 API Reference 部分显示为空，因为：
1. Sphinx autoapi 只配置扫描 `.pyi` 文件
2. `algorithms` 模块没有 `.pyi` 存根文件
3. autodoc 无法导入 `pysparq.algorithms.grover` 等模块（需要C++扩展）

## Solution

- 为 `algorithms` 模块添加 `.pyi` 类型存根文件
- 更新 `conf.py` 使 autoapi 同时扫描 `.pyi` 和 `.py` 文件

## Files Changed

- `PySparQ/pysparq/algorithms/__init__.pyi` - 新增
- `PySparQ/pysparq/algorithms/grover.pyi` - 新增
- `PySparQ/pysparq/algorithms/shor.pyi` - 新增  
- `PySparQ/pysparq/algorithms/cks_solver.pyi` - 新增
- `PySparQ/pysparq/algorithms/qda_solver.pyi` - 新增
- `docs/sphinx/source/conf.py` - 修改 autoapi_file_patterns

## Test plan

- [ ] 本地构建Sphinx文档验证
- [ ] 检查算法文档API Reference部分是否正常显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)