### PR TITLE
docs: add badges and fix math formulas & TOC warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 [![arXiv:SparQ](https://img.shields.io/badge/SparQ-arXiv%3A2503%2E15118-6f42c1.svg)](https://arxiv.org/abs/2503.15118)
 [![PyPI](https://img.shields.io/pypi/v/pysparq.svg)](https://pypi.org/project/pysparq/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![GitHub](https://img.shields.io/badge/GitHub-IAI--USTC--Quantum%2FQRAM--Simulator-181717?logo=github)](https://github.com/IAI-USTC-Quantum/QRAM-Simulator)
+[![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-4D6AE4)](https://iai-ustc-quantum.github.io/QRAM-Simulator/)
+[![CMake on multiple platforms](https://github.com/IAI-USTC-Quantum/QRAM-Simulator/actions/workflows/cmake-multi-platform.yml/badge.svg)](https://github.com/IAI-USTC-Quantum/QRAM-Simulator/actions/workflows/cmake-multi-platform.yml)
 
 > **稀疏态量子模拟器，支持 Register Level Programming**
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -235,6 +235,9 @@
                 <a href="https://arxiv.org/abs/2503.15118"><img src="https://img.shields.io/badge/SparQ-arXiv%3A2503%2E15118-6f42c1.svg" alt="arXiv: SparQ"></a>
                 <img src="https://img.shields.io/pypi/v/pysparq.svg" alt="PyPI">
                 <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License">
+                <a href="https://github.com/IAI-USTC-Quantum/QRAM-Simulator"><img src="https://img.shields.io/badge/GitHub-IAI--USTC--Quantum%2FQRAM--Simulator-181717?logo=github" alt="GitHub"></a>
+                <a href="https://iai-ustc-quantum.github.io/QRAM-Simulator/"><img src="https://img.shields.io/badge/docs-GitHub%20Pages-4D6AE4" alt="Documentation"></a>
+                <a href="https://github.com/IAI-USTC-Quantum/QRAM-Simulator/actions/workflows/cmake-multi-platform.yml"><img src="https://github.com/IAI-USTC-Quantum/QRAM-Simulator/actions/workflows/cmake-multi-platform.yml/badge.svg" alt="CI"></a>
             </div>
         </header>
 

--- a/docs/sphinx/source/guide/algorithms/cks_solver.rst
+++ b/docs/sphinx/source/guide/algorithms/cks_solver.rst
@@ -3,6 +3,7 @@ CKS Linear System Solver
 
 .. contents:: Table of Contents
    :local:
+   :class: this-will-duplicate-information-and-it-is-still-useful-here
 
 Overview
 --------
@@ -38,7 +39,7 @@ The walk operator is:
 
 .. math::
 
-   W = T^\\dagger \\cdot R \\cdot T \\cdot \\text{Swap}
+   W = T^\dagger \cdot R \cdot T \cdot \text{Swap}
 
 where:
 
@@ -50,7 +51,7 @@ The T operator creates superposition over non-zero columns:
 
 .. math::
 
-   |\\psi_j\\rangle = \\sum_{k: A_{jk} \\neq 0} \\sqrt{|A_{jk}|} |k\\rangle
+   |\psi_j\rangle = \sum_{k: A_{jk} \neq 0} \sqrt{|A_{jk}|} |k\rangle
 
 LCU Construction
 ~~~~~~~~~~~~~~~~~
@@ -59,7 +60,7 @@ The solution is constructed as:
 
 .. math::
 
-   |x\\rangle \\propto \\sum_{j=0}^{j_0} c_j W^j |b\\rangle
+   |x\rangle \propto \sum_{j=0}^{j_0} c_j W^j |b\rangle
 
 where c_j are Chebyshev polynomial coefficients.
 
@@ -284,7 +285,7 @@ The CKS algorithm achieves:
 
 .. math::
 
-   T = O(\\kappa \\log(\\kappa/\\epsilon))
+   T = O(\kappa \log(\kappa/\epsilon))
 
 compared to O(κ² log(κ/ε)) for classical iterative methods.
 

--- a/docs/sphinx/source/guide/algorithms/grover.rst
+++ b/docs/sphinx/source/guide/algorithms/grover.rst
@@ -3,6 +3,7 @@ Grover's Quantum Search Algorithm
 
 .. contents:: Table of Contents
    :local:
+   :class: this-will-duplicate-information-and-it-is-still-useful-here
 
 Overview
 --------
@@ -31,7 +32,7 @@ The algorithm consists of three main steps:
 
    .. math::
 
-      |\\psi_0\\rangle = \\frac{1}{\\sqrt{N}} \\sum_{x=0}^{N-1} |x\\rangle
+      |\psi_0\rangle = \frac{1}{\sqrt{N}} \sum_{x=0}^{N-1} |x\rangle
 
 2. **Grover Iteration**: Repeatedly apply G = D · O
 
@@ -39,7 +40,7 @@ The algorithm consists of three main steps:
 
      .. math::
 
-        O|x\\rangle = (-1)^{f(x)} |x\\rangle
+        O|x\rangle = (-1)^{f(x)} |x\rangle
 
      where f(x) = 1 if x is marked, 0 otherwise.
 
@@ -47,7 +48,7 @@ The algorithm consists of three main steps:
 
      .. math::
 
-        D = 2|s\\rangle\\langle s| - I
+        D = 2|s\rangle\langle s| - I
 
      where |s⟩ is the uniform superposition.
 
@@ -60,15 +61,15 @@ After k iterations, the amplitude of marked states is:
 
 .. math::
 
-   a_k = \\sin((2k+1)\\theta)
+   a_k = \sin((2k+1)\theta)
 
-where :math:`\\theta = \\arcsin(\\sqrt{M/N})` and M is the number of marked items.
+where :math:`\theta = \arcsin(\sqrt{M/N})` and M is the number of marked items.
 
 Optimal number of iterations:
 
 .. math::
 
-   k_{opt} \\approx \\frac{\\pi}{4}\\sqrt{\\frac{N}{M}}
+   k_{opt} \approx \frac{\pi}{4}\sqrt{\frac{N}{M}}
 
 Implementation Steps
 --------------------

--- a/docs/sphinx/source/guide/algorithms/qda_solver.rst
+++ b/docs/sphinx/source/guide/algorithms/qda_solver.rst
@@ -3,6 +3,7 @@ QDA Linear System Solver
 
 .. contents:: Table of Contents
    :local:
+   :class: this-will-duplicate-information-and-it-is-still-useful-here
 
 Overview
 --------
@@ -44,7 +45,7 @@ The algorithm uses block encoding to represent H(s):
 
 .. math::
 
-   U_{H(s)} = \\begin{pmatrix} H(s) & \\cdot \\\\ \\cdot & \\cdot \\end{pmatrix}
+   U_{H(s)} = \begin{pmatrix} H(s) & \cdot \\ \cdot & \cdot \end{pmatrix}
 
 Quantum Walk
 ~~~~~~~~~~~~
@@ -53,7 +54,7 @@ The walk operator W_s combines block encoding with reflection:
 
 .. math::
 
-   W_s = R \\cdot U_{H(s)}
+   W_s = R \cdot U_{H(s)}
 
 Applied repeatedly via LCU construction.
 
@@ -319,7 +320,7 @@ The QDA algorithm achieves optimal scaling:
 
 .. math::
 
-   T = O(\\kappa \\log(\\kappa/\\epsilon))
+   T = O(\kappa \log(\kappa/\epsilon))
 
 This is provably optimal for quantum linear system solvers.
 
@@ -337,14 +338,14 @@ Interpolation Function (Eq. 69)
 
 .. math::
 
-   f(s) = \\frac{\\kappa}{\\kappa - 1}\\left(1 - \\left(1 + s(\\kappa^{p-1} - 1)\\right)^{\\frac{1}{1-p}}\\right)
+   f(s) = \frac{\kappa}{\kappa - 1}\left(1 - \left(1 + s(\kappa^{p-1} - 1)\right)^{\frac{1}{1-p}}\right)
 
 Rotation Matrix
 ~~~~~~~~~~~~~~~
 
 .. math::
 
-   R_s = \\frac{1}{\\sqrt{(1-f)^2 + f^2}} \\begin{pmatrix} 1-f & f \\\\ f & f-1 \\end{pmatrix}
+   R_s = \frac{1}{\sqrt{(1-f)^2 + f^2}} \begin{pmatrix} 1-f & f \\ f & f-1 \end{pmatrix}
 
 API Reference
 -------------

--- a/docs/sphinx/source/guide/algorithms/shor.rst
+++ b/docs/sphinx/source/guide/algorithms/shor.rst
@@ -3,6 +3,7 @@ Shor's Quantum Factorization Algorithm
 
 .. contents:: Table of Contents
    :local:
+   :class: this-will-duplicate-information-and-it-is-still-useful-here
 
 Overview
 --------
@@ -35,13 +36,13 @@ The quantum part finds the period r of the function:
 
 .. math::
 
-   f(x) = a^x \\mod N
+   f(x) = a^x \mod N
 
 Using quantum phase estimation on unitary:
 
 .. math::
 
-   U|x\\rangle = |x \\oplus 1\\rangle
+   U|x\rangle = |x \oplus 1\rangle
 
 The eigenvalues of U are e^(2πik/r), giving the period.
 
@@ -52,7 +53,7 @@ The measurement result y/Q is related to c/r via:
 
 .. math::
 
-   \\frac{y}{Q} \\approx \\frac{c}{r}
+   \frac{y}{Q} \approx \frac{c}{r}
 
 where Q = 2^size (the precision register size).
 
@@ -309,7 +310,7 @@ The ModMul operation computes:
 
 .. math::
 
-   |y\\rangle \\rightarrow |y \\cdot a^{2^x} \\mod N\\rangle
+   |y\rangle \rightarrow |y \cdot a^{2^x} \mod N\rangle
 
 controlled by the work qubit.
 
@@ -320,7 +321,7 @@ After measuring bit x, we apply phase corrections for bits x+1, x+2, ...:
 
 .. math::
 
-   R_z\\left(-\\frac{2\\pi b_j}{2^{j-i}}\\right)
+   R_z\left(-\frac{2\pi b_j}{2^{j-i}}\right)
 
 This implements the iterative phase estimation correctly.
 


### PR DESCRIPTION
## Summary

- Add GitHub repository, Documentation, and CI badges to README.md and docs/index.html
- Fix double backslash escaping in math blocks (\\ → \) across all algorithm documentation files for proper MathJax rendering
- Add Furo escape hatch class to `.. contents::` directive to suppress TOC warning

## Changes

| File | Change |
|------|--------|
| README.md | +3 badges (GitHub, Documentation, CI) |
| docs/index.html | +3 badges (GitHub, Documentation, CI) |
| grover.rst | Math formula fix + TOC class |
| shor.rst | Math formula fix + TOC class |
| cks_solver.rst | Math formula fix + TOC class |
| qda_solver.rst | Math formula fix + TOC class |

## Test plan

- [x] Sphinx build succeeds without TOC warning
- [x] Math formulas render correctly (verified in generated HTML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)