### PR TITLE
fix: add link to PyPI badge in Sphinx index

### DIFF
--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -8,7 +8,7 @@ PySparQ is a sparse-state quantum circuit simulator with native QRAM support and
    <div class="badges" style="display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 20px;">
      <a href="https://arxiv.org/abs/2503.13832"><img src="https://img.shields.io/badge/QRAM_Simulator-arXiv%3A2503%2E13832-b31b1b.svg" alt="arXiv"></a>
      <a href="https://arxiv.org/abs/2503.15118"><img src="https://img.shields.io/badge/SparQ-arXiv%3A2503%2E15118-6f42c1.svg" alt="arXiv"></a>
-     <img src="https://img.shields.io/pypi/v/pysparq.svg" alt="PyPI">
+     <a href="https://pypi.org/project/pysparq/"><img src="https://img.shields.io/pypi/v/pysparq.svg" alt="PyPI"></a>
      <a href="https://github.com/IAI-USTC-Quantum/QRAM-Simulator"><img src="https://img.shields.io/badge/GitHub-Repo-181717?logo=github" alt="GitHub"></a>
      <a href="https://iai-ustc-quantum.github.io/QRAM-Simulator/"><img src="https://img.shields.io/badge/docs-GitHub%20Pages-4D6AE4" alt="Documentation"></a>
    </div>


### PR DESCRIPTION
## Summary
- Add hyperlink to PyPI badge pointing to https://pypi.org/project/pysparq/

## Test plan
- [ ] Verify badge links correctly to PyPI package page

🤖 Generated with [Claude Code](https://claude.com/claude-code)