### PR TITLE
feat: add setuptools_scm versioning and PyPI publishing workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,89 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build_wheels:
+    name: Build wheel (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install CMake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.26.x'
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22
+        env:
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
+          CIBW_SKIP: "*-musllinux_* *-win32"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Build sdist
+        run: |
+          pip install build setuptools-scm
+          python -m build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  publish:
+    name: Publish to PyPI
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event_name == 'release'
+    environment:
+      name: pypi
+      url: https://pypi.org/project/pysparq/
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist/
+          merge-multiple: true
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,8 @@ __pycache__/
 pyqsparse.egg-info/
 /wheelhouse/
 
+# Auto-generated version file (setuptools_scm)
+PySparQ/pysparq/_version.py
+
 # Sphinx documentation build
 docs/sphinx/build/

--- a/PySparQ/__init__.py
+++ b/PySparQ/__init__.py
@@ -13,10 +13,11 @@ try:
         BaseOperator,
         SelfAdjointOperator,
         StateStorage,
+        __version__,
     )
 except ImportError:
     # pysparq._core 可能尚未编译
-    pass
+    __version__ = "0.0.0.dev0"
 
 # 导入动态算子模块
 try:
@@ -35,6 +36,6 @@ __all__ = [
     "StateStorage",
     # 动态算子
     "compile_operator",
+    # 版本
+    "__version__",
 ]
-
-__version__ = "0.2.0"

--- a/PySparQ/pysparq/__init__.py
+++ b/PySparQ/pysparq/__init__.py
@@ -27,6 +27,13 @@ See Also:
 
 from __future__ import annotations
 
+# Import version from auto-generated _version.py
+try:
+    from ._version import __version__, __version_tuple__
+except ImportError:
+    __version__ = "0.0.0.dev0"
+    __version_tuple__ = (0, 0, 0, "dev0")
+
 from ._core import *
 from .dynamic_operator import compile_operator, CompilationError, DynamicOperatorError
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["scikit-build-core>=0.10"]
+requires = ["scikit-build-core>=0.10", "setuptools-scm>=8"]
 build-backend = "scikit_build_core.build"
 
 [project]
 name = "pysparq"
-version = "0.0.1"
+dynamic = ["version"]
 description = "A sparse state quantum circuit simulator"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -20,6 +20,11 @@ cmake.version = ">=3.15"
 cmake.build-type = "Release"
 wheel.packages = ["PySparQ/pysparq"]
 ninja.make-fallback = false
+metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
+
+[tool.setuptools_scm]
+write_to = "PySparQ/pysparq/_version.py"
+fallback_version = "0.0.0"
 
 
 [tool.cibuildwheel]


### PR DESCRIPTION
## Summary
- Integrate `setuptools_scm` for automatic version management from git tags (via scikit-build-core's built-in provider)
- Add `PySparQ/pysparq/_version.py` auto-generation with fallback for development installs
- Create `.github/workflows/pypi-publish.yml` for automated PyPI publishing using OIDC trusted publishing
- Unify version definitions (previously `pyproject.toml` had `0.0.1` vs `__init__.py` had `0.2.0`)

## Changes
| File | Change |
|------|--------|
| `pyproject.toml` | Add `setuptools-scm>=8` to build requires, switch `version` to dynamic, configure `metadata.version.provider` and `[tool.setuptools_scm]` |
| `PySparQ/pysparq/__init__.py` | Import `__version__` from auto-generated `_version.py` with fallback |
| `PySparQ/__init__.py` | Import `__version__` from `.pysparq` submodule, remove hardcoded `0.2.0` |
| `.gitignore` | Exclude auto-generated `_version.py` |
| `.github/workflows/pypi-publish.yml` | New workflow: cibuildwheel multi-platform builds + sdist + OIDC publish to PyPI |

## Publishing Flow
1. Push a version tag: `git tag v0.1.0 && git push origin v0.1.0`
2. CI builds wheels (Linux/Windows/macOS) and sdist
3. Publishes to PyPI via OIDC trusted publishing (no API tokens needed)

## Prerequisites
Before first publish, configure OIDC trusted publishing on PyPI:
- Owner: `Agony5757`, Repository: `QRAM-Simulator`
- Workflow: `pypi-publish.yml`, Environment: `pypi`

## Test plan
- [ ] Verify `pip install .` still works with setuptools_scm
- [ ] Verify `python -c "import pysparq; print(pysparq.__version__)"` shows correct version
- [ ] Test workflow triggers on tag push (can test with a pre-release tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)