### PR TITLE
fix: use dnf for manylinux OpenMP install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ skip = ["*-musllinux_*", "*-win32", "*-macos*"]
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64"]
-before-all = "yum install -y libgomp-devel"
+before-all = "dnf install -y libgomp-devel"
 
 [tool.cibuildwheel.windows]
 archs = ["AMD64"]


### PR DESCRIPTION
## Summary
- Change `yum install` to `dnf install` for libgomp-devel in cibuildwheel Linux config
- Default manylinux images (manylinux_2_28) are AlmaLinux-based and use dnf, not yum

## Test plan
- [ ] Verify cibuildwheel Linux build succeeds with dnf
- [ ] Verify v0.1.0 PyPI publish after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)