### PR TITLE
fix: correct yum package name for OpenMP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ skip = ["*-musllinux_*", "*-win32", "*-macos*"]
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64"]
-before-all = "dnf install -y libgomp-devel"
+before-all = "yum install -y libgomp"
 
 [tool.cibuildwheel.windows]
 archs = ["AMD64"]


### PR DESCRIPTION
## Summary
- Fix package name to `libgomp` (not `libgomp-devel` or `dnf`)

## Test plan
- [ ] Verify cibuildwheel Linux build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)