### PR TITLE
fix: use Development.Module for Python find_package

### DIFF
--- a/PySparQ/CMakeLists.txt
+++ b/PySparQ/CMakeLists.txt
@@ -12,7 +12,7 @@ project(
 # Find the module development requirements (requires FindPython from 3.17 or
 # scikit-build-core's built-in backport)
 # Use FindPython3 to match what pybind11 uses
-find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
 # find_package(pybind11 CONFIG REQUIRED)
 
 # Add a library using FindPython's tooling (pybind11 also provides a helper like


### PR DESCRIPTION
## Summary
- Change `find_package(Python3 ... Development)` to `Development.Module`
- CMake's `Development` component requires `Development.Embed` which is not available in manylinux containers
- pybind11 only needs `Development.Module` for building Python extension modules

## Test plan
- [ ] Verify cibuildwheel Linux build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)