### PR TITLE
fix: use pybind11_add_module instead of python_add_library

### DIFF
--- a/PySparQ/CMakeLists.txt
+++ b/PySparQ/CMakeLists.txt
@@ -12,18 +12,12 @@ project(
 # Find the module development requirements (requires FindPython from 3.17 or
 # scikit-build-core's built-in backport)
 # Use FindPython3 to match what pybind11 uses
-find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
-# find_package(pybind11 CONFIG REQUIRED)
+find_package(pybind11 CONFIG REQUIRED)
 
-# Add a library using FindPython's tooling (pybind11 also provides a helper like
-# this)
-python_add_library(_core MODULE core.cpp WITH_SOABI)
-target_link_libraries(_core PRIVATE pybind11::headers)
+pybind11_add_module(_core core.cpp)
 target_link_libraries(_core PRIVATE SparQ)
 
-# Add dynamic_operator module
-python_add_library(_dynamic_operator MODULE pysparq/dynamic_operator/src/dynamic_operator_loader.cpp WITH_SOABI)
-target_link_libraries(_dynamic_operator PRIVATE pybind11::headers)
+pybind11_add_module(_dynamic_operator pysparq/dynamic_operator/src/dynamic_operator_loader.cpp)
 target_include_directories(_dynamic_operator PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/pysparq/dynamic_operator/include
     ${CMAKE_SOURCE_DIR}/SparQ/include

--- a/PySparQ/CMakeLists.txt
+++ b/PySparQ/CMakeLists.txt
@@ -9,10 +9,8 @@ project(
   VERSION ${SKBUILD_PROJECT_VERSION}
   LANGUAGES CXX)
 
-# Find the module development requirements (requires FindPython from 3.17 or
-# scikit-build-core's built-in backport)
-# Use FindPython3 to match what pybind11 uses
-find_package(pybind11 CONFIG REQUIRED)
+# pybind11 is provided by ThirdParty/CMakeLists.txt (add_subdirectory)
+# pybind11_add_module is available without find_package here
 
 pybind11_add_module(_core core.cpp)
 target_link_libraries(_core PRIVATE SparQ)


### PR DESCRIPTION
## Summary
- Replace `python_add_library` with `pybind11_add_module` in PySparQ/CMakeLists.txt
- Remove `find_package(Python3 ... Development)` which fails in manylinux containers missing Development.Embed
- `pybind11_add_module` handles Python discovery internally via pybind11's own CMake config

## Test plan
- [ ] Verify cibuildwheel Linux build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)