### PR TITLE
docs: restructure toctree and fix CLAUDE.md git workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,11 +95,13 @@ Doxygen documentation is auto-deployed on push to `main`:
 
 ## Git Workflow
 
-**IMPORTANT: Never push directly to `upstream/main`. Always work on fork and submit PRs.**
+**IMPORTANT: Never push directly to the upstream repo. Always work on fork and submit PRs.**
 
-Remote configuration:
+Repository role:
 - `origin` → personal fork (`Agony5757/QRAM-Simulator`), active development
-- `upstream` → organization repo (`IAI-USTC-Quantum/QRAM-Simulator`), PR target
+- Upstream (`IAI-USTC-Quantum/QRAM-Simulator`) — PR target, accessed via `gh` CLI (no `upstream` git remote configured)
+
+Cross-repo operations (sync, PR) rely on `gh` CLI rather than a git upstream remote.
 
 ### CI Verification Before Submitting to Upstream
 
@@ -113,6 +115,11 @@ Remote configuration:
 ### Typical Workflow
 
 ```bash
+# Sync fork with upstream first
+gh repo sync Agony5757/QRAM-Simulator --source IAI-USTC-Quantum/QRAM-Simulator --branch main
+git fetch origin
+git rebase origin/main
+
 # Create feature branch from origin (fork)
 git checkout -b feature/my-feature origin/main
 
@@ -134,6 +141,7 @@ gh pr create --repo IAI-USTC-Quantum/QRAM-Simulator \
 ```bash
 gh repo sync Agony5757/QRAM-Simulator --source IAI-USTC-Quantum/QRAM-Simulator --branch main
 git fetch origin
+git rebase origin/main
 ```
 
 ### CI Jobs

--- a/docs/sphinx/source/guide/core_concepts/index.rst
+++ b/docs/sphinx/source/guide/core_concepts/index.rst
@@ -10,6 +10,7 @@
    sparse_state
    register_management
    register_types
+   operators
 
 核心抽象
 --------

--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -47,6 +47,19 @@ PySparQ 是一个稀疏态量子电路模拟器，具有原生 QRAM 支持和寄
    :caption: 算子参考
 
    operators/index
+   operators/arithmetic
+   operators/gates
+   operators/hadamard
+   operators/qft
+   operators/condrot
+   operators/phase_ops
+   operators/rot_state_prep
+   operators/qram_ops
+   operators/system_ops
+   operators/partial_trace
+   operators/sort_ops
+   operators/dark_magic
+   operators/debug
 
 .. toctree::
    :maxdepth: 2

--- a/docs/sphinx/source/operators/index.rst
+++ b/docs/sphinx/source/operators/index.rst
@@ -7,44 +7,6 @@
    :local:
    :class: this-will-duplicate-information-and-it-is-still-useful-here
 
-.. toctree::
-   :maxdepth: 2
-   :caption: 量子算术
-
-   arithmetic
-
-.. toctree::
-   :maxdepth: 2
-   :caption: 量子门与变换
-
-   gates
-   hadamard
-   qft
-   condrot
-   phase_ops
-   rot_state_prep
-
-.. toctree::
-   :maxdepth: 2
-   :caption: QRAM 操作
-
-   qram_ops
-
-.. toctree::
-   :maxdepth: 2
-   :caption: 系统操作
-
-   system_ops
-   partial_trace
-   sort_ops
-
-.. toctree::
-   :maxdepth: 2
-   :caption: 辅助工具
-
-   dark_magic
-   debug
-
 什么是算子？
 ------------
 


### PR DESCRIPTION
## Summary

- **Sidebar 结构扁平化**: 将算子参考页面直接列在根 toctree 中，与"用户指南"保持一致的目录逻辑
- **核心概念合并**: "量子态与寄存器表示"和"算子"合并为同一个"核心概念" section，通过 `guide/core_concepts/index.rst` 的子 toctree 组织
- **CLAUDE.md 修正**: 移除不存在的 `upstream` remote 声明，改为说明通过 `gh` CLI 完成跨仓库操作

## Test plan

- [ ] Sphinx 构建：`cd docs/sphinx && make html` 无警告通过
- [ ] 检查侧边栏：核心概念展开显示 System/SparseState/寄存器管理/寄存器类型/算子
- [ ] 检查侧边栏：算子参考展开显示所有分类页面
- [ ] 确认 `operators/index.rst` 无 toctree（页面由根 index 管理）

🤖 Generated with [Claude Code](https://claude.com/claude-code)