### PR TITLE
docs: optimize Sphinx TOC structure and fix broken references

### DIFF
--- a/docs/sphinx/source/api/python.rst
+++ b/docs/sphinx/source/api/python.rst
@@ -16,14 +16,6 @@ PySparQ 通过 :mod:`pysparq` 模块将所有量子操作暴露为 Python 类和
    :members:
    :show-inheritance:
 
-.. autoclass:: pysparq._core.BaseOperator
-   :members:
-   :show-inheritance:
-
-.. autoclass:: pysparq._core.SelfAdjointOperator
-   :members:
-   :show-inheritance:
-
 量子算术算子
 ------------
 
@@ -81,4 +73,4 @@ QRAM 操作
 完整 API 文档
 -------------
 
-完整的 API 文档（所有类、函数和方法），请参见 :doc:`API 参考 </autoapi/PySparQ/pysparq/index>`。
+完整的 API 文档（所有类、函数和方法），请参见 :ref:`modindex`。

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -94,7 +94,7 @@ autoapi_dirs = ["../../../PySparQ/pysparq"]
 autoapi_root = "autoapi"
 autoapi_file_patterns = ["*.pyi", "*.py"]
 autoapi_generate_api_docs = True
-autoapi_add_toctree_entry = False
+autoapi_add_toctree_entry = True
 autoapi_options = [
     "members",
     "undoc-members",

--- a/docs/sphinx/source/guide/core_concepts/register_management.rst
+++ b/docs/sphinx/source/guide/core_concepts/register_management.rst
@@ -197,46 +197,9 @@ PartialTrace：测量
 API 参考
 --------
 
-.. autoclass:: pysparq.AddRegister
-   :members:
-   :undoc-members:
+寄存器管理算子的完整 API 文档，请参见以下算子参考页面：
 
-.. autoclass:: pysparq.RemoveRegister
-   :members:
-   :undoc-members:
+- :doc:`Push / Pop / ClearZero 等系统操作 </operators/system_ops>`
+- :doc:`PartialTrace 测量算子 </operators/partial_trace>`
 
-.. autoclass:: pysparq.SplitRegister
-   :members:
-   :undoc-members:
-
-.. autoclass:: pysparq.CombineRegister
-   :members:
-   :undoc-members:
-
-.. autoclass:: pysparq.PartialTrace
-   :members:
-   :undoc-members:
-
-.. autoclass:: pysparq.PartialTraceSelect
-   :members:
-   :undoc-members:
-
-.. autoclass:: pysparq.PartialTraceSelectRange
-   :members:
-   :undoc-members:
-
-.. autoclass:: pysparq.AddRegisterWithHadamard
-   :members:
-   :undoc-members:
-
-.. autoclass:: pysparq.Push
-   :members:
-   :undoc-members:
-
-.. autoclass:: pysparq.Pop
-   :members:
-   :undoc-members:
-
-.. autoclass:: pysparq.ClearZero
-   :members:
-   :undoc-members:
+或查阅 :ref:`算子参考` 章节获取所有算子的完整列表。

--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -20,7 +20,7 @@ PySparQ 是一个稀疏态量子电路模拟器，具有原生 QRAM 支持和寄
 * `主页 <https://iai-ustc-quantum.github.io/QRAM-Simulator/>`_ - 项目概览和 C++ API 文档
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
    :caption: 用户指南
 
    guide/installation
@@ -29,11 +29,6 @@ PySparQ 是一个稀疏态量子电路模拟器，具有原生 QRAM 支持和寄
    guide/examples
    guide/dynamic_operators
    guide/algorithms/index
-
-.. toctree::
-   :maxdepth: 2
-   :caption: 核心概念
-
    guide/core_concepts/index
 
 .. toctree::
@@ -41,19 +36,6 @@ PySparQ 是一个稀疏态量子电路模拟器，具有原生 QRAM 支持和寄
    :caption: 算子参考
 
    operators/index
-   operators/arithmetic
-   operators/gates
-   operators/hadamard
-   operators/qft
-   operators/condrot
-   operators/phase_ops
-   operators/rot_state_prep
-   operators/qram_ops
-   operators/system_ops
-   operators/partial_trace
-   operators/sort_ops
-   operators/dark_magic
-   operators/debug
 
 .. toctree::
    :maxdepth: 2
@@ -68,7 +50,6 @@ PySparQ 是一个稀疏态量子电路模拟器，具有原生 QRAM 支持和寄
    :caption: API 参考
 
    api/index
-   autoapi/PySparQ/pysparq/index
 
 快速开始
 --------

--- a/docs/sphinx/source/operators/index.rst
+++ b/docs/sphinx/source/operators/index.rst
@@ -216,3 +216,25 @@ API 参考
 .. autoclass:: pysparq.SelfAdjointOperator
    :members:
    :undoc-members:
+
+.. _算子参考:
+
+算子分类详解
+-----------
+
+.. toctree::
+   :maxdepth: 2
+
+   arithmetic
+   gates
+   hadamard
+   qft
+   condrot
+   phase_ops
+   rot_state_prep
+   qram_ops
+   system_ops
+   partial_trace
+   sort_ops
+   dark_magic
+   debug


### PR DESCRIPTION
## Summary

- Merge "核心概念" into "用户指南" toctree, reducing top-level sections from 5 to 4 for cleaner sidebar navigation
- Nest 13 operator detail pages under `operators/index.rst` sub-toctree instead of flat listing in root
- Remove broken `autoapi/PySparQ/pysparq/index` reference and enable `autoapi_add_toctree_entry = True`
- Add `.. _算子参考:` label to fix broken `:ref:` cross-reference from `core_concepts/operators.rst`
- Remove duplicate `autoclass` directives from `register_management.rst` and `api/python.rst`, replace with cross-reference links

## Test plan

- [x] `sphinx-build` completes without toctree/reference/label warnings
- [ ] Verify sidebar navigation renders correctly in browser (4 top-level sections, nested operator pages)
- [ ] Verify `:ref:`算子参考`` cross-reference resolves correctly
- [ ] Verify autoapi pages are auto-included in docs