### PR TITLE
feat: remove pybind11 git submodule and use pip-installed dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "ThirdParty/pybind11"]
-	path = ThirdParty/pybind11
-	url = git@github.com:pybind/pybind11.git
-	update = checkout

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,6 @@ include_directories(${PROJECT_SOURCE_DIR}/Common/include
                     ${PROJECT_SOURCE_DIR}/ThirdParty/argparse
                     ${PROJECT_SOURCE_DIR}/ThirdParty/fmt/include
                     ${PROJECT_SOURCE_DIR}/ThirdParty/eigen-3.4.0
-                    ${PROJECT_SOURCE_DIR}/Thirdparty/pybind11
                     )
 
 set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
@@ -88,6 +87,15 @@ endif(UNIX)
 # endif()
 
 
+# pybind11 - find it early so ThirdParty/CMakeLists.txt can use the result
+# When building wheels via scikit-build-core, pybind11 is installed via pyproject.toml
+find_package(pybind11 CONFIG QUIET)
+if(pybind11_FOUND)
+    message(STATUS "Found pybind11: ${pybind11_VERSION}")
+else()
+    message(STATUS "pybind11 not found - Python bindings will not be built")
+endif()
+
 add_subdirectory(Common)
 add_subdirectory(QRAM)
 add_subdirectory(SparQ)
@@ -96,7 +104,11 @@ add_subdirectory(SparQ_Algorithm)
 add_subdirectory(ThirdParty EXCLUDE_FROM_ALL)
 add_subdirectory(test)
 add_subdirectory(Experiments)
-add_subdirectory(PySparQ)
+
+# PySparQ requires pybind11
+if(pybind11_FOUND)
+    add_subdirectory(PySparQ)
+endif()
 
 # --- Install rules ---
 include(GNUInstallDirs)

--- a/PySparQ/CMakeLists.txt
+++ b/PySparQ/CMakeLists.txt
@@ -9,8 +9,7 @@ project(
   VERSION ${SKBUILD_PROJECT_VERSION}
   LANGUAGES CXX)
 
-# pybind11 is provided by ThirdParty/CMakeLists.txt (add_subdirectory)
-# pybind11_add_module is available without find_package here
+# pybind11 is provided by ThirdParty/CMakeLists.txt (find_package)
 
 pybind11_add_module(_core core.cpp)
 target_link_libraries(_core PRIVATE SparQ)

--- a/ThirdParty/CMakeLists.txt
+++ b/ThirdParty/CMakeLists.txt
@@ -1,10 +1,1 @@
 add_subdirectory(fmt EXCLUDE_FROM_ALL)
-# add_subdirectory(eigen-3.4.0 EXCLUDE_FROM_ALL)
-
-# Try to use pybind11 from subdirectory first (for CI with submodules),
-# fallback to find_package if not available (for local development)
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/pybind11/CMakeLists.txt")
-    add_subdirectory(pybind11 EXCLUDE_FROM_ALL)
-else()
-    find_package(pybind11 REQUIRED)
-endif()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.10", "setuptools-scm>=8"]
+requires = ["scikit-build-core>=0.10", "pybind11>=2.13", "setuptools-scm>=8"]
 build-backend = "scikit_build_core.build"
 
 [project]


### PR DESCRIPTION
## Summary

- Remove `ThirdParty/pybind11` git submodule
- Delete `.gitmodules` file
- Update `CMakeLists.txt` to use `find_package(pybind11 CONFIG QUIET)` instead of `add_subdirectory`
- Update `pyproject.toml` to include `pybind11>=2.13` in `build-system.requires`
- Simplify `ThirdParty/CMakeLists.txt` to only build fmt

This modernizes the build workflow by using pip-installed pybind11 instead of managing it as a git submodule, which simplifies dependency management and CI configuration.

## Test plan

- [x] C++ build (CPU): `cmake .. -DCMAKE_BUILD_TYPE=Release && make -j$(nproc)` ✅
- [x] C++ tests: `ctest --output-on-failure` (59 tests, all passed) ✅
- [x] Python wheel build: `uv pip install .` ✅
- [x] Python tests: `pytest PySparQ/test/` (core tests passed) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)