### PR TITLE
fix(docs): execute notebooks in CI and fix print(pprint) anti-pattern

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -229,7 +229,10 @@ jobs:
     - name: Install Documentation Dependencies
       run: |
         pip install -r docs/sphinx/requirements.txt
-        sudo apt-get update && sudo apt-get install -y doxygen graphviz pandoc
+        sudo apt-get update && sudo apt-get install -y doxygen graphviz pandoc libgomp1
+
+    - name: Install pysparq for notebook execution
+      run: pip install .
 
     - name: Generate Doxygen Documentation
       run: doxygen Doxyfile

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -147,7 +147,7 @@ copybutton_here_doc_delimiter = "EOT"
 # -- nbsphinx options --------------------------------------------------------
 # https://nbsphinx.readthedocs.io/
 
-nbsphinx_execute = "never"  # Don't execute notebooks during build
+nbsphinx_execute = "auto"  # Execute notebooks if pysparq is available
 nbsphinx_allow_errors = False
 nbsphinx_timeout = 60
 # Note: nbsphinx prolog/epilog templates use env.docname instead of docname

--- a/docs/sphinx/source/notebooks/02_稀疏态演化.ipynb
+++ b/docs/sphinx/source/notebooks/02_稀疏态演化.ipynb
@@ -28,7 +28,7 @@
     }
    ],
    "source": [
-    "import pysparq as ps\n\nps.System.clear()\n\n# 创建 2 比特寄存器\nps.System.add_register(\"q\", ps.UnsignedInteger, 2)\n\n# 初始状态\nstate = ps.SparseState()\n\nprint(\"初始状态:\")\nprint(ps.pprint(state))\nprint(f\"\\n基态数量: {state.size()}\")"
+    "import pysparq as ps\n\nps.System.clear()\n\n# 创建 2 比特寄存器\nps.System.add_register(\"q\", ps.UnsignedInteger, 2)\n\n# 初始状态\nstate = ps.SparseState()\n\nprint(\"初始状态:\")\nps.pprint(state))\nprint(f\"\\n基态数量: {state.size()}\")"
    ]
   },
   {
@@ -63,7 +63,7 @@
     }
    ],
    "source": [
-    "# Hadamard_Int: 对指定数量的量子比特应用 Hadamard\nps.Hadamard_Int(\"q\", 1)(state)\n\nprint(\"Hadamard_Int(q, 1) 后:\")\nprint(ps.pprint(state))\nprint(f\"\\n基态数量: {state.size()}\")"
+    "# Hadamard_Int: 对指定数量的量子比特应用 Hadamard\nps.Hadamard_Int(\"q\", 1)(state)\n\nprint(\"Hadamard_Int(q, 1) 后:\")\nps.pprint(state))\nprint(f\"\\n基态数量: {state.size()}\")"
    ]
   },
   {
@@ -89,7 +89,7 @@
     }
    ],
    "source": [
-    "# Hadamard_Int_Full: 对所有量子比特应用完整 Hadamard\nps.Hadamard_Int_Full(\"q\")(state)\n\nprint(\"Hadamard_Int_Full(q) 后:\")\nprint(ps.pprint(state))\nprint(f\"\\n基态数量: {state.size()}\")"
+    "# Hadamard_Int_Full: 对所有量子比特应用完整 Hadamard\nps.Hadamard_Int_Full(\"q\")(state)\n\nprint(\"Hadamard_Int_Full(q) 后:\")\nps.pprint(state))\nprint(f\"\\n基态数量: {state.size()}\")"
    ]
   },
   {
@@ -146,7 +146,7 @@
     }
    ],
    "source": [
-    "print(\"Binary 模式:\")\nprint(ps.pprint(state, mode=ps.StatePrintDisplay.Binary))"
+    "print(\"Binary 模式:\")\nps.pprint(state, mode=ps.StatePrintDisplay.Binary))"
    ]
   },
   {
@@ -170,7 +170,7 @@
     }
    ],
    "source": [
-    "print(\"Prob 模式:\")\nprint(ps.pprint(state, mode=ps.StatePrintDisplay.Prob))"
+    "print(\"Prob 模式:\")\nps.pprint(state, mode=ps.StatePrintDisplay.Prob))"
    ]
   },
   {
@@ -201,7 +201,7 @@
     }
    ],
    "source": [
-    "ps.System.clear()\n\n# 创建寄存器\nps.System.add_register(\"a\", ps.UnsignedInteger, 2)\nps.System.add_register(\"b\", ps.UnsignedInteger, 2)\nps.System.add_register(\"sum\", ps.UnsignedInteger, 2)\n\nstate = ps.SparseState()\n\n# 初始化\nps.Init_Unsafe(\"a\", 1)(state)\nps.Init_Unsafe(\"b\", 2)(state)\n\nprint(\"初始状态:\")\nprint(ps.pprint(state))"
+    "ps.System.clear()\n\n# 创建寄存器\nps.System.add_register(\"a\", ps.UnsignedInteger, 2)\nps.System.add_register(\"b\", ps.UnsignedInteger, 2)\nps.System.add_register(\"sum\", ps.UnsignedInteger, 2)\n\nstate = ps.SparseState()\n\n# 初始化\nps.Init_Unsafe(\"a\", 1)(state)\nps.Init_Unsafe(\"b\", 2)(state)\n\nprint(\"初始状态:\")\nps.pprint(state))"
    ]
   },
   {
@@ -225,7 +225,7 @@
     }
    ],
    "source": [
-    "# 加法: sum ^= a + b\nps.Add_UInt_UInt(\"a\", \"b\", \"sum\")(state)\n\nprint(\"Add_UInt_UInt 后:\")\nprint(ps.pprint(state))\n# sum = 0 ^ (1 + 2) = 3"
+    "# 加法: sum ^= a + b\nps.Add_UInt_UInt(\"a\", \"b\", \"sum\")(state)\n\nprint(\"Add_UInt_UInt 后:\")\nps.pprint(state))\n# sum = 0 ^ (1 + 2) = 3"
    ]
   },
   {
@@ -249,7 +249,7 @@
     }
    ],
    "source": [
-    "# 再次应用 = 撤销（XOR 机制）\nps.Add_UInt_UInt(\"a\", \"b\", \"sum\")(state)\n\nprint(\"再次 Add_UInt_UInt 后:\")\nprint(ps.pprint(state))\n# sum = 3 ^ 3 = 0"
+    "# 再次应用 = 撤销（XOR 机制）\nps.Add_UInt_UInt(\"a\", \"b\", \"sum\")(state)\n\nprint(\"再次 Add_UInt_UInt 后:\")\nps.pprint(state))\n# sum = 3 ^ 3 = 0"
    ]
   },
   {
@@ -280,7 +280,7 @@
     }
    ],
    "source": [
-    "ps.System.clear()\n\nps.System.add_register(\"x\", ps.UnsignedInteger, 2)\nps.System.add_register(\"y\", ps.UnsignedInteger, 2)\n\nstate = ps.SparseState()\n\n# x 处于叠加态\nps.Hadamard_Int_Full(\"x\")(state)\n\n# y 初始化为常数\nps.Init_Unsafe(\"y\", 1)(state)\n\nprint(\"初始叠加态:\")\nprint(ps.pprint(state))"
+    "ps.System.clear()\n\nps.System.add_register(\"x\", ps.UnsignedInteger, 2)\nps.System.add_register(\"y\", ps.UnsignedInteger, 2)\n\nstate = ps.SparseState()\n\n# x 处于叠加态\nps.Hadamard_Int_Full(\"x\")(state)\n\n# y 初始化为常数\nps.Init_Unsafe(\"y\", 1)(state)\n\nprint(\"初始叠加态:\")\nps.pprint(state))"
    ]
   },
   {
@@ -304,7 +304,7 @@
     }
    ],
    "source": [
-    "# 内置加法: y += x（每个分支独立计算）\nps.Add_UInt_UInt_InPlace(\"x\", \"y\")(state)\n\nprint(\"Add_UInt_UInt_InPlace 后:\")\nprint(ps.pprint(state))\n# 每个分支: y = 1 + x"
+    "# 内置加法: y += x（每个分支独立计算）\nps.Add_UInt_UInt_InPlace(\"x\", \"y\")(state)\n\nprint(\"Add_UInt_UInt_InPlace 后:\")\nps.pprint(state))\n# 每个分支: y = 1 + x"
    ]
   },
   {
@@ -328,7 +328,7 @@
     }
    ],
    "source": [
-    "# 撤销\nps.Add_UInt_UInt_InPlace(\"x\", \"y\").dag(state)\n\nprint(\"dagger 后:\")\nprint(ps.pprint(state))"
+    "# 撤销\nps.Add_UInt_UInt_InPlace(\"x\", \"y\").dag(state)\n\nprint(\"dagger 后:\")\nps.pprint(state))"
    ]
   },
   {

--- a/docs/sphinx/source/notebooks/03_算子示例.ipynb
+++ b/docs/sphinx/source/notebooks/03_算子示例.ipynb
@@ -85,7 +85,7 @@
     }
    ],
    "source": [
-    "# 外置加法: result ^= a + b\nps.Add_UInt_UInt(\"a\", \"b\", \"result\")(state)\nprint(\"Add_UInt_UInt:\")\nprint(ps.pprint(state))"
+    "# 外置加法: result ^= a + b\nps.Add_UInt_UInt(\"a\", \"b\", \"result\")(state)\nprint(\"Add_UInt_UInt:\")\nps.pprint(state))"
    ]
   },
   {
@@ -109,7 +109,7 @@
     }
    ],
    "source": [
-    "# 内置加法: b += a\nps.System.clear()\nps.System.add_register(\"a\", ps.UnsignedInteger, 4)\nps.System.add_register(\"b\", ps.UnsignedInteger, 4)\nstate = ps.SparseState()\nps.Init_Unsafe(\"a\", 7)(state)\nps.Init_Unsafe(\"b\", 10)(state)\n\nop = ps.Add_UInt_UInt_InPlace(\"a\", \"b\")\nop(state)\nprint(\"Add_UInt_UInt_InPlace:\")\nprint(ps.pprint(state))\n# b = (10 + 7) % 16 = 1"
+    "# 内置加法: b += a\nps.System.clear()\nps.System.add_register(\"a\", ps.UnsignedInteger, 4)\nps.System.add_register(\"b\", ps.UnsignedInteger, 4)\nstate = ps.SparseState()\nps.Init_Unsafe(\"a\", 7)(state)\nps.Init_Unsafe(\"b\", 10)(state)\n\nop = ps.Add_UInt_UInt_InPlace(\"a\", \"b\")\nop(state)\nprint(\"Add_UInt_UInt_InPlace:\")\nps.pprint(state))\n# b = (10 + 7) % 16 = 1"
    ]
   },
   {
@@ -133,7 +133,7 @@
     }
    ],
    "source": [
-    "# 撤销\nop.dag(state)\nprint(\"dagger 后:\")\nprint(ps.pprint(state))"
+    "# 撤销\nop.dag(state)\nprint(\"dagger 后:\")\nps.pprint(state))"
    ]
   },
   {
@@ -164,7 +164,7 @@
     }
    ],
    "source": [
-    "ps.System.clear()\nps.System.add_register(\"x\", ps.UnsignedInteger, 4)\nps.System.add_register(\"triple\", ps.UnsignedInteger, 4)\n\nstate = ps.SparseState()\nps.Init_Unsafe(\"x\", 5)(state)\n\n# 乘以奇数常量（保证双射）\nps.Mult_UInt_ConstUInt(\"x\", 3, \"triple\")(state)\nprint(\"Mult_UInt_ConstUInt(x, 3):\")\nprint(ps.pprint(state))"
+    "ps.System.clear()\nps.System.add_register(\"x\", ps.UnsignedInteger, 4)\nps.System.add_register(\"triple\", ps.UnsignedInteger, 4)\n\nstate = ps.SparseState()\nps.Init_Unsafe(\"x\", 5)(state)\n\n# 乘以奇数常量（保证双射）\nps.Mult_UInt_ConstUInt(\"x\", 3, \"triple\")(state)\nprint(\"Mult_UInt_ConstUInt(x, 3):\")\nps.pprint(state))"
    ]
   },
   {
@@ -195,7 +195,7 @@
     }
    ],
    "source": [
-    "ps.System.clear()\nps.System.add_register(\"a\", ps.UnsignedInteger, 4)\nps.System.add_register(\"b\", ps.UnsignedInteger, 4)\nps.System.add_register(\"less\", ps.Boolean, 1)\nps.System.add_register(\"equal\", ps.Boolean, 1)\n\nstate = ps.SparseState()\nps.Init_Unsafe(\"a\", 3)(state)\nps.Init_Unsafe(\"b\", 5)(state)\n\nps.Compare_UInt_UInt(\"a\", \"b\", \"less\", \"equal\")(state)\nprint(\"Compare_UInt_UInt:\")\nprint(ps.pprint(state))"
+    "ps.System.clear()\nps.System.add_register(\"a\", ps.UnsignedInteger, 4)\nps.System.add_register(\"b\", ps.UnsignedInteger, 4)\nps.System.add_register(\"less\", ps.Boolean, 1)\nps.System.add_register(\"equal\", ps.Boolean, 1)\n\nstate = ps.SparseState()\nps.Init_Unsafe(\"a\", 3)(state)\nps.Init_Unsafe(\"b\", 5)(state)\n\nps.Compare_UInt_UInt(\"a\", \"b\", \"less\", \"equal\")(state)\nprint(\"Compare_UInt_UInt:\")\nps.pprint(state))"
    ]
   },
   {
@@ -226,7 +226,7 @@
     }
    ],
    "source": [
-    "ps.System.clear()\nps.System.add_register(\"q\", ps.Boolean, 1)\n\nstate = ps.SparseState()\nprint(\"初始:\")\nprint(ps.pprint(state))"
+    "ps.System.clear()\nps.System.add_register(\"q\", ps.Boolean, 1)\n\nstate = ps.SparseState()\nprint(\"初始:\")\nps.pprint(state))"
    ]
   },
   {
@@ -250,7 +250,7 @@
     }
    ],
    "source": [
-    "# X 门（NOT）\nps.Xgate_Bool(\"q\", 0)(state)\nprint(\"X 门后:\")\nprint(ps.pprint(state))"
+    "# X 门（NOT）\nps.Xgate_Bool(\"q\", 0)(state)\nprint(\"X 门后:\")\nps.pprint(state))"
    ]
   },
   {
@@ -274,7 +274,7 @@
     }
    ],
    "source": [
-    "# Hadamard\nps.Hadamard_Bool(\"q\")(state)\nprint(\"Hadamard 后:\")\nprint(ps.pprint(state))"
+    "# Hadamard\nps.Hadamard_Bool(\"q\")(state)\nprint(\"Hadamard 后:\")\nps.pprint(state))"
    ]
   },
   {
@@ -298,7 +298,7 @@
     }
    ],
    "source": [
-    "# 相位门\nps.Phase_Bool(\"q\", 0, np.pi/4)(state)\nprint(\"Phase(π/4) 后:\")\nprint(ps.pprint(state))"
+    "# 相位门\nps.Phase_Bool(\"q\", 0, np.pi/4)(state)\nprint(\"Phase(π/4) 后:\")\nps.pprint(state))"
    ]
   },
   {
@@ -329,7 +329,7 @@
     }
    ],
    "source": [
-    "ps.System.clear()\nps.System.add_register(\"q\", ps.UnsignedInteger, 3)\n\nstate = ps.SparseState()\nps.Init_Unsafe(\"q\", 1)(state)\n\nprint(\"初始:\")\nprint(ps.pprint(state))"
+    "ps.System.clear()\nps.System.add_register(\"q\", ps.UnsignedInteger, 3)\n\nstate = ps.SparseState()\nps.Init_Unsafe(\"q\", 1)(state)\n\nprint(\"初始:\")\nps.pprint(state))"
    ]
   },
   {
@@ -353,7 +353,7 @@
     }
    ],
    "source": [
-    "# QFT\nps.QFT(\"q\")(state)\nprint(\"QFT 后:\")\nprint(ps.pprint(state))"
+    "# QFT\nps.QFT(\"q\")(state)\nprint(\"QFT 后:\")\nps.pprint(state))"
    ]
   },
   {
@@ -377,7 +377,7 @@
     }
    ],
    "source": [
-    "# inverseQFT\nps.inverseQFT(\"q\")(state)\nprint(\"inverseQFT 后:\")\nprint(ps.pprint(state))"
+    "# inverseQFT\nps.inverseQFT(\"q\")(state)\nprint(\"inverseQFT 后:\")\nps.pprint(state))"
    ]
   },
   {
@@ -408,7 +408,7 @@
     }
    ],
    "source": [
-    "ps.System.clear()\nps.System.add_register(\"x\", ps.UnsignedInteger, 2)\nps.System.add_register(\"result\", ps.UnsignedInteger, 2)\nps.System.add_register(\"ctrl\", ps.Boolean, 1)\n\nstate = ps.SparseState()\nps.Init_Unsafe(\"x\", 3)(state)\nps.Init_Unsafe(\"ctrl\", 1)(state)\n\n# 当 ctrl = 1 时执行加法\nps.Add_UInt_ConstUInt(\"x\", 5, \"result\").conditioned_by_nonzeros(\"ctrl\")(state)\n\nprint(\"条件加法 (ctrl=1):\")\nprint(ps.pprint(state))"
+    "ps.System.clear()\nps.System.add_register(\"x\", ps.UnsignedInteger, 2)\nps.System.add_register(\"result\", ps.UnsignedInteger, 2)\nps.System.add_register(\"ctrl\", ps.Boolean, 1)\n\nstate = ps.SparseState()\nps.Init_Unsafe(\"x\", 3)(state)\nps.Init_Unsafe(\"ctrl\", 1)(state)\n\n# 当 ctrl = 1 时执行加法\nps.Add_UInt_ConstUInt(\"x\", 5, \"result\").conditioned_by_nonzeros(\"ctrl\")(state)\n\nprint(\"条件加法 (ctrl=1):\")\nps.pprint(state))"
    ]
   },
   {
@@ -432,7 +432,7 @@
     }
    ],
    "source": [
-    "# ctrl = 0 时条件不触发\nps.System.clear()\nps.System.add_register(\"x\", ps.UnsignedInteger, 2)\nps.System.add_register(\"result\", ps.UnsignedInteger, 2)\nps.System.add_register(\"ctrl\", ps.Boolean, 1)\n\nstate = ps.SparseState()\nps.Init_Unsafe(\"x\", 3)(state)\nps.Init_Unsafe(\"ctrl\", 0)(state)  # ctrl = 0\n\nps.Add_UInt_ConstUInt(\"x\", 5, \"result\").conditioned_by_nonzeros(\"ctrl\")(state)\n\nprint(\"条件加法 (ctrl=0):\")\nprint(ps.pprint(state))\n# result 保持 0"
+    "# ctrl = 0 时条件不触发\nps.System.clear()\nps.System.add_register(\"x\", ps.UnsignedInteger, 2)\nps.System.add_register(\"result\", ps.UnsignedInteger, 2)\nps.System.add_register(\"ctrl\", ps.Boolean, 1)\n\nstate = ps.SparseState()\nps.Init_Unsafe(\"x\", 3)(state)\nps.Init_Unsafe(\"ctrl\", 0)(state)  # ctrl = 0\n\nps.Add_UInt_ConstUInt(\"x\", 5, \"result\").conditioned_by_nonzeros(\"ctrl\")(state)\n\nprint(\"条件加法 (ctrl=0):\")\nps.pprint(state))\n# result 保持 0"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Remove outer `print()` wrapper around `ps.pprint()` calls in notebooks: `print(ps.pprint(state))` prints `"None"` — should be `ps.pprint(state)` alone so `sys.stdout.write()` output is captured in the output cell.
- Enable nbsphinx notebook execution (`nbsphinx_execute = "auto"`) so HTML docs show actual state output.
- Install pysparq in CI docs job (`pip install .`) so notebooks can execute during Sphinx build.

## Test plan
- [ ] CI docs job passes (notebook cells execute and produce output)
- [ ] Notebook HTML pages show state output cells (e.g. `03_算子示例.html`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)