### PR TITLE
fix(notebooks): remove double closing parenthesis in ps.pprint() calls

### DIFF
--- a/docs/sphinx/source/notebooks/02_稀疏态演化.ipynb
+++ b/docs/sphinx/source/notebooks/02_稀疏态演化.ipynb
@@ -17,9 +17,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "import pysparq as ps\n\nps.System.clear()\n\n# 创建 2 比特寄存器\nps.System.add_register(\"q\", ps.UnsignedInteger, 2)\n\n# 初始状态\nstate = ps.SparseState()\n\nprint(\"初始状态:\")\nps.pprint(state))\nprint(f\"\\n基态数量: {state.size()}\")"
-   ]
+   "source": "import pysparq as ps\n\nps.System.clear()\n\n# 创建 2 比特寄存器\nps.System.add_register(\"q\", ps.UnsignedInteger, 2)\n\n# 初始状态\nstate = ps.SparseState()\n\nprint(\"初始状态:\")\nps.pprint(state)\nprint(f\"\\n基态数量: {state.size()}\")"
   },
   {
    "cell_type": "markdown",
@@ -42,9 +40,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "# Hadamard_Int: 对指定数量的量子比特应用 Hadamard\nps.Hadamard_Int(\"q\", 1)(state)\n\nprint(\"Hadamard_Int(q, 1) 后:\")\nps.pprint(state))\nprint(f\"\\n基态数量: {state.size()}\")"
-   ]
+   "source": "# Hadamard_Int: 对指定数量的量子比特应用 Hadamard\nps.Hadamard_Int(\"q\", 1)(state)\n\nprint(\"Hadamard_Int(q, 1) 后:\")\nps.pprint(state)\nprint(f\"\\n基态数量: {state.size()}\")"
   },
   {
    "cell_type": "code",
@@ -58,9 +54,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "# Hadamard_Int_Full: 对所有量子比特应用完整 Hadamard\nps.Hadamard_Int_Full(\"q\")(state)\n\nprint(\"Hadamard_Int_Full(q) 后:\")\nps.pprint(state))\nprint(f\"\\n基态数量: {state.size()}\")"
-   ]
+   "source": "# Hadamard_Int_Full: 对所有量子比特应用完整 Hadamard\nps.Hadamard_Int_Full(\"q\")(state)\n\nprint(\"Hadamard_Int_Full(q) 后:\")\nps.pprint(state)\nprint(f\"\\n基态数量: {state.size()}\")"
   },
   {
    "cell_type": "markdown",
@@ -138,9 +132,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "ps.System.clear()\n\n# 创建寄存器\nps.System.add_register(\"a\", ps.UnsignedInteger, 2)\nps.System.add_register(\"b\", ps.UnsignedInteger, 2)\nps.System.add_register(\"sum\", ps.UnsignedInteger, 2)\n\nstate = ps.SparseState()\n\n# 初始化\nps.Init_Unsafe(\"a\", 1)(state)\nps.Init_Unsafe(\"b\", 2)(state)\n\nprint(\"初始状态:\")\nps.pprint(state))"
-   ]
+   "source": "ps.System.clear()\n\n# 创建寄存器\nps.System.add_register(\"a\", ps.UnsignedInteger, 2)\nps.System.add_register(\"b\", ps.UnsignedInteger, 2)\nps.System.add_register(\"sum\", ps.UnsignedInteger, 2)\n\nstate = ps.SparseState()\n\n# 初始化\nps.Init_Unsafe(\"a\", 1)(state)\nps.Init_Unsafe(\"b\", 2)(state)\n\nprint(\"初始状态:\")\nps.pprint(state)"
   },
   {
    "cell_type": "code",
@@ -154,9 +146,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "# 加法: sum ^= a + b\nps.Add_UInt_UInt(\"a\", \"b\", \"sum\")(state)\n\nprint(\"Add_UInt_UInt 后:\")\nps.pprint(state))\n# sum = 0 ^ (1 + 2) = 3"
-   ]
+   "source": "# 加法: sum ^= a + b\nps.Add_UInt_UInt(\"a\", \"b\", \"sum\")(state)\n\nprint(\"Add_UInt_UInt 后:\")\nps.pprint(state)\n# sum = 0 ^ (1 + 2) = 3"
   },
   {
    "cell_type": "code",
@@ -170,9 +160,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "# 再次应用 = 撤销（XOR 机制）\nps.Add_UInt_UInt(\"a\", \"b\", \"sum\")(state)\n\nprint(\"再次 Add_UInt_UInt 后:\")\nps.pprint(state))\n# sum = 3 ^ 3 = 0"
-   ]
+   "source": "# 再次应用 = 撤销（XOR 机制）\nps.Add_UInt_UInt(\"a\", \"b\", \"sum\")(state)\n\nprint(\"再次 Add_UInt_UInt 后:\")\nps.pprint(state)\n# sum = 3 ^ 3 = 0"
   },
   {
    "cell_type": "markdown",
@@ -193,9 +181,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "ps.System.clear()\n\nps.System.add_register(\"x\", ps.UnsignedInteger, 2)\nps.System.add_register(\"y\", ps.UnsignedInteger, 2)\n\nstate = ps.SparseState()\n\n# x 处于叠加态\nps.Hadamard_Int_Full(\"x\")(state)\n\n# y 初始化为常数\nps.Init_Unsafe(\"y\", 1)(state)\n\nprint(\"初始叠加态:\")\nps.pprint(state))"
-   ]
+   "source": "ps.System.clear()\n\nps.System.add_register(\"x\", ps.UnsignedInteger, 2)\nps.System.add_register(\"y\", ps.UnsignedInteger, 2)\n\nstate = ps.SparseState()\n\n# x 处于叠加态\nps.Hadamard_Int_Full(\"x\")(state)\n\n# y 初始化为常数\nps.Init_Unsafe(\"y\", 1)(state)\n\nprint(\"初始叠加态:\")\nps.pprint(state)"
   },
   {
    "cell_type": "code",
@@ -209,9 +195,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "# 内置加法: y += x（每个分支独立计算）\nps.Add_UInt_UInt_InPlace(\"x\", \"y\")(state)\n\nprint(\"Add_UInt_UInt_InPlace 后:\")\nps.pprint(state))\n# 每个分支: y = 1 + x"
-   ]
+   "source": "# 内置加法: y += x（每个分支独立计算）\nps.Add_UInt_UInt_InPlace(\"x\", \"y\")(state)\n\nprint(\"Add_UInt_UInt_InPlace 后:\")\nps.pprint(state)\n# 每个分支: y = 1 + x"
   },
   {
    "cell_type": "code",
@@ -225,9 +209,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "# 撤销\nps.Add_UInt_UInt_InPlace(\"x\", \"y\").dag(state)\n\nprint(\"dagger 后:\")\nps.pprint(state))"
-   ]
+   "source": "# 撤销\nps.Add_UInt_UInt_InPlace(\"x\", \"y\").dag(state)\n\nprint(\"dagger 后:\")\nps.pprint(state)"
   },
   {
    "cell_type": "markdown",

--- a/docs/sphinx/source/notebooks/03_算子示例.ipynb
+++ b/docs/sphinx/source/notebooks/03_算子示例.ipynb
@@ -76,9 +76,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "# 外置加法: result ^= a + b\nps.Add_UInt_UInt(\"a\", \"b\", \"result\")(state)\nprint(\"Add_UInt_UInt:\")\nps.pprint(state))"
-   ]
+   "source": "# 外置加法: result ^= a + b\nps.Add_UInt_UInt(\"a\", \"b\", \"result\")(state)\nprint(\"Add_UInt_UInt:\")\nps.pprint(state)"
   },
   {
    "cell_type": "code",
@@ -92,9 +90,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "# 内置加法: b += a\nps.System.clear()\nps.System.add_register(\"a\", ps.UnsignedInteger, 4)\nps.System.add_register(\"b\", ps.UnsignedInteger, 4)\nstate = ps.SparseState()\nps.Init_Unsafe(\"a\", 7)(state)\nps.Init_Unsafe(\"b\", 10)(state)\n\nop = ps.Add_UInt_UInt_InPlace(\"a\", \"b\")\nop(state)\nprint(\"Add_UInt_UInt_InPlace:\")\nps.pprint(state))\n# b = (10 + 7) % 16 = 1"
-   ]
+   "source": "# 内置加法: b += a\nps.System.clear()\nps.System.add_register(\"a\", ps.UnsignedInteger, 4)\nps.System.add_register(\"b\", ps.UnsignedInteger, 4)\nstate = ps.SparseState()\nps.Init_Unsafe(\"a\", 7)(state)\nps.Init_Unsafe(\"b\", 10)(state)\n\nop = ps.Add_UInt_UInt_InPlace(\"a\", \"b\")\nop(state)\nprint(\"Add_UInt_UInt_InPlace:\")\nps.pprint(state)\n# b = (10 + 7) % 16 = 1"
   },
   {
    "cell_type": "code",
@@ -108,9 +104,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "# 撤销\nop.dag(state)\nprint(\"dagger 后:\")\nps.pprint(state))"
-   ]
+   "source": "# 撤销\nop.dag(state)\nprint(\"dagger 后:\")\nps.pprint(state)"
   },
   {
    "cell_type": "markdown",
@@ -131,9 +125,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "ps.System.clear()\nps.System.add_register(\"x\", ps.UnsignedInteger, 4)\nps.System.add_register(\"triple\", ps.UnsignedInteger, 4)\n\nstate = ps.SparseState()\nps.Init_Unsafe(\"x\", 5)(state)\n\n# 乘以奇数常量（保证双射）\nps.Mult_UInt_ConstUInt(\"x\", 3, \"triple\")(state)\nprint(\"Mult_UInt_ConstUInt(x, 3):\")\nps.pprint(state))"
-   ]
+   "source": "ps.System.clear()\nps.System.add_register(\"x\", ps.UnsignedInteger, 4)\nps.System.add_register(\"triple\", ps.UnsignedInteger, 4)\n\nstate = ps.SparseState()\nps.Init_Unsafe(\"x\", 5)(state)\n\n# 乘以奇数常量（保证双射）\nps.Mult_UInt_ConstUInt(\"x\", 3, \"triple\")(state)\nprint(\"Mult_UInt_ConstUInt(x, 3):\")\nps.pprint(state)"
   },
   {
    "cell_type": "markdown",
@@ -154,9 +146,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "ps.System.clear()\nps.System.add_register(\"a\", ps.UnsignedInteger, 4)\nps.System.add_register(\"b\", ps.UnsignedInteger, 4)\nps.System.add_register(\"less\", ps.Boolean, 1)\nps.System.add_register(\"equal\", ps.Boolean, 1)\n\nstate = ps.SparseState()\nps.Init_Unsafe(\"a\", 3)(state)\nps.Init_Unsafe(\"b\", 5)(state)\n\nps.Compare_UInt_UInt(\"a\", \"b\", \"less\", \"equal\")(state)\nprint(\"Compare_UInt_UInt:\")\nps.pprint(state))"
-   ]
+   "source": "ps.System.clear()\nps.System.add_register(\"a\", ps.UnsignedInteger, 4)\nps.System.add_register(\"b\", ps.UnsignedInteger, 4)\nps.System.add_register(\"less\", ps.Boolean, 1)\nps.System.add_register(\"equal\", ps.Boolean, 1)\n\nstate = ps.SparseState()\nps.Init_Unsafe(\"a\", 3)(state)\nps.Init_Unsafe(\"b\", 5)(state)\n\nps.Compare_UInt_UInt(\"a\", \"b\", \"less\", \"equal\")(state)\nprint(\"Compare_UInt_UInt:\")\nps.pprint(state)"
   },
   {
    "cell_type": "markdown",
@@ -177,9 +167,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "ps.System.clear()\nps.System.add_register(\"q\", ps.Boolean, 1)\n\nstate = ps.SparseState()\nprint(\"初始:\")\nps.pprint(state))"
-   ]
+   "source": "ps.System.clear()\nps.System.add_register(\"q\", ps.Boolean, 1)\n\nstate = ps.SparseState()\nprint(\"初始:\")\nps.pprint(state)"
   },
   {
    "cell_type": "code",
@@ -193,9 +181,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "# X 门（NOT）\nps.Xgate_Bool(\"q\", 0)(state)\nprint(\"X 门后:\")\nps.pprint(state))"
-   ]
+   "source": "# X 门（NOT）\nps.Xgate_Bool(\"q\", 0)(state)\nprint(\"X 门后:\")\nps.pprint(state)"
   },
   {
    "cell_type": "code",
@@ -209,9 +195,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "# Hadamard\nps.Hadamard_Bool(\"q\")(state)\nprint(\"Hadamard 后:\")\nps.pprint(state))"
-   ]
+   "source": "# Hadamard\nps.Hadamard_Bool(\"q\")(state)\nprint(\"Hadamard 后:\")\nps.pprint(state)"
   },
   {
    "cell_type": "code",
@@ -225,9 +209,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "# 相位门\nps.Phase_Bool(\"q\", 0, np.pi/4)(state)\nprint(\"Phase(π/4) 后:\")\nps.pprint(state))"
-   ]
+   "source": "# 相位门\nps.Phase_Bool(\"q\", 0, np.pi/4)(state)\nprint(\"Phase(π/4) 后:\")\nps.pprint(state)"
   },
   {
    "cell_type": "markdown",
@@ -248,9 +230,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "ps.System.clear()\nps.System.add_register(\"q\", ps.UnsignedInteger, 3)\n\nstate = ps.SparseState()\nps.Init_Unsafe(\"q\", 1)(state)\n\nprint(\"初始:\")\nps.pprint(state))"
-   ]
+   "source": "ps.System.clear()\nps.System.add_register(\"q\", ps.UnsignedInteger, 3)\n\nstate = ps.SparseState()\nps.Init_Unsafe(\"q\", 1)(state)\n\nprint(\"初始:\")\nps.pprint(state)"
   },
   {
    "cell_type": "code",
@@ -264,9 +244,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "# QFT\nps.QFT(\"q\")(state)\nprint(\"QFT 后:\")\nps.pprint(state))"
-   ]
+   "source": "# QFT\nps.QFT(\"q\")(state)\nprint(\"QFT 后:\")\nps.pprint(state)"
   },
   {
    "cell_type": "code",
@@ -280,9 +258,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "# inverseQFT\nps.inverseQFT(\"q\")(state)\nprint(\"inverseQFT 后:\")\nps.pprint(state))"
-   ]
+   "source": "# inverseQFT\nps.inverseQFT(\"q\")(state)\nprint(\"inverseQFT 后:\")\nps.pprint(state)"
   },
   {
    "cell_type": "markdown",
@@ -303,9 +279,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "ps.System.clear()\nps.System.add_register(\"x\", ps.UnsignedInteger, 2)\nps.System.add_register(\"result\", ps.UnsignedInteger, 2)\nps.System.add_register(\"ctrl\", ps.Boolean, 1)\n\nstate = ps.SparseState()\nps.Init_Unsafe(\"x\", 3)(state)\nps.Init_Unsafe(\"ctrl\", 1)(state)\n\n# 当 ctrl = 1 时执行加法\nps.Add_UInt_ConstUInt(\"x\", 5, \"result\").conditioned_by_nonzeros(\"ctrl\")(state)\n\nprint(\"条件加法 (ctrl=1):\")\nps.pprint(state))"
-   ]
+   "source": "ps.System.clear()\nps.System.add_register(\"x\", ps.UnsignedInteger, 2)\nps.System.add_register(\"result\", ps.UnsignedInteger, 2)\nps.System.add_register(\"ctrl\", ps.Boolean, 1)\n\nstate = ps.SparseState()\nps.Init_Unsafe(\"x\", 3)(state)\nps.Init_Unsafe(\"ctrl\", 1)(state)\n\n# 当 ctrl = 1 时执行加法\nps.Add_UInt_ConstUInt(\"x\", 5, \"result\").conditioned_by_nonzeros(\"ctrl\")(state)\n\nprint(\"条件加法 (ctrl=1):\")\nps.pprint(state)"
   },
   {
    "cell_type": "code",
@@ -319,9 +293,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "# ctrl = 0 时条件不触发\nps.System.clear()\nps.System.add_register(\"x\", ps.UnsignedInteger, 2)\nps.System.add_register(\"result\", ps.UnsignedInteger, 2)\nps.System.add_register(\"ctrl\", ps.Boolean, 1)\n\nstate = ps.SparseState()\nps.Init_Unsafe(\"x\", 3)(state)\nps.Init_Unsafe(\"ctrl\", 0)(state)  # ctrl = 0\n\nps.Add_UInt_ConstUInt(\"x\", 5, \"result\").conditioned_by_nonzeros(\"ctrl\")(state)\n\nprint(\"条件加法 (ctrl=0):\")\nps.pprint(state))\n# result 保持 0"
-   ]
+   "source": "# ctrl = 0 时条件不触发\nps.System.clear()\nps.System.add_register(\"x\", ps.UnsignedInteger, 2)\nps.System.add_register(\"result\", ps.UnsignedInteger, 2)\nps.System.add_register(\"ctrl\", ps.Boolean, 1)\n\nstate = ps.SparseState()\nps.Init_Unsafe(\"x\", 3)(state)\nps.Init_Unsafe(\"ctrl\", 0)(state)  # ctrl = 0\n\nps.Add_UInt_ConstUInt(\"x\", 5, \"result\").conditioned_by_nonzeros(\"ctrl\")(state)\n\nprint(\"条件加法 (ctrl=0):\")\nps.pprint(state)\n# result 保持 0"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
修复所有 notebook 中 `ps.pprint(state))` 多余右括号导致的 SyntaxError，共涉及 2 个文件 23 处。

## Test plan
- [ ] CI docs job passes
- [ ] 部署后 notebook 无 SyntaxError

🤖 Generated with [Claude Code](https://claude.com/claude-code)