### PR TITLE
fix(docs): expand interactive notebook content and fix operators link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -316,7 +316,7 @@
                 <p data-i18n="card_cpp_desc">Doxygen-generated C++ API for SparQ core, quantum gates, arithmetic operators, and QRAM circuits.</p>
                 <span class="arrow" data-i18n="card_cpp_arrow">Browse docs &rarr;</span>
             </a>
-            <a class="card" href="operators.html">
+            <a class="card" href="operators.md">
                 <h2 data-i18n="card_ops_title">Operators Reference</h2>
                 <p data-i18n="card_ops_desc">Detailed documentation for quantum arithmetic operators and unitary guarantees.</p>
                 <span class="arrow" data-i18n="card_ops_arrow">View reference &rarr;</span>

--- a/docs/sphinx/source/notebooks/02_稀疏态演化.ipynb
+++ b/docs/sphinx/source/notebooks/02_稀疏态演化.ipynb
@@ -93,9 +93,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "print(\"Binary 模式:\")\nps.pprint(state, mode=ps.StatePrintDisplay.Binary))"
-   ]
+   "source": "print(\"Binary 模式:\")\nps.pprint(state, mode=ps.StatePrintDisplay.Binary)"
   },
   {
    "cell_type": "code",
@@ -109,9 +107,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "print(\"Prob 模式:\")\nps.pprint(state, mode=ps.StatePrintDisplay.Prob))"
-   ]
+   "source": "print(\"Prob 模式:\")\nps.pprint(state, mode=ps.StatePrintDisplay.Prob)"
   },
   {
    "cell_type": "markdown",
@@ -246,9 +242,31 @@
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## QRAM 数据加载\n\n在叠加态下通过 QRAM 批量加载经典数据：\n\n```python\nimport numpy as np\n\nps.System.clear()\nn_addr, n_data = 3, 4\nps.System.add_register(\"addr\", ps.UnsignedInteger, n_addr)\nps.System.add_register(\"data\", ps.UnsignedInteger, n_data)\n\nstate = ps.SparseState()\n\n# 经典数据（8 个内存位置）\nmemory = np.array([1, 3, 5, 7, 2, 4, 6, 8], dtype=np.uint64)\n\n# 对地址寄存器叠加 → 同时查询所有地址\nps.Hadamard_Int(\"addr\")(state)\n\n# QRAM 加载：data = memory[addr]\nqram = ps.QRAMCircuit_qutrit(n_addr, n_data, memory)\nps.QRAMLoad(qram, \"addr\", \"data\")(state)\n\n# 状态包含所有 (addr, memory[addr]) 对的振幅\nprint(ps.StatePrint()(state))\nprint(f\"\\n基态数量: {state.size()}\")\n```\n\nQRAM 加载后，状态为所有 :math:`|addr\\rangle \\otimes |memory[addr]\\rangle` 的叠加，基态数等于地址空间大小。\n\n## QFT 变换\n\n```python\nps.System.clear()\nps.System.add_register(\"reg\", ps.UnsignedInteger, 3)\nstate = ps.SparseState()\n\nps.Init_Unsafe(\"reg\", 1)(state)\nprint(\"初始:\")\nprint(ps.StatePrint()(state))\n\nps.QFT(\"reg\")(state)\nprint(\"QFT 后:\")\nprint(ps.StatePrint()(state))\n\nps.inverseQFT(\"reg\")(state)\nprint(\"逆 QFT 后:\")\nprint(ps.StatePrint()(state))  # 恢复到 |1⟩\n```\n\n## 总结\n\n- SparseState 只存储非零基态，基态数量随叠加增长\n- Hadamard 创建叠加态\n- 算术操作作用于每个基态（稀疏遍历）\n- SelfAdjointOperator 两次应用恢复原值，BaseOperator 用 dag() 撤销\n- QRAM 在叠加态下实现经典数据的批量查询\n- QFT / inverseQFT 用于相位估计类算法"
-   ],
+   "source": "## QRAM 数据加载\n\n在叠加态下通过 QRAM 批量加载经典数据：",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "import numpy as np\n\nps.System.clear()\nn_addr, n_data = 3, 4\nps.System.add_register(\"addr\", ps.UnsignedInteger, n_addr)\nps.System.add_register(\"data\", ps.UnsignedInteger, n_data)\n\nstate = ps.SparseState()\n\n# 经典数据（8 个内存位置）\nmemory = np.array([1, 3, 5, 7, 2, 4, 6, 8], dtype=np.uint64)\n\n# 对地址寄存器叠加 → 同时查询所有地址\nps.Hadamard_Int(\"addr\")(state)\n\n# QRAM 加载：data = memory[addr]\nqram = ps.QRAMCircuit_qutrit(n_addr, n_data, memory)\nps.QRAMLoad(qram, \"addr\", \"data\")(state)\n\n# 状态包含所有 (addr, memory[addr]) 对的振幅\nprint(ps.StatePrint()(state))\nprint(f\"\\n基态数量: {state.size()}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## QFT 变换",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "ps.System.clear()\nps.System.add_register(\"reg\", ps.UnsignedInteger, 3)\nstate = ps.SparseState()\n\nps.Init_Unsafe(\"reg\", 1)(state)\nprint(\"初始:\")\nprint(ps.StatePrint()(state))\n\nps.QFT(\"reg\")(state)\nprint(\"QFT 后:\")\nprint(ps.StatePrint()(state))\n\nps.inverseQFT(\"reg\")(state)\nprint(\"逆 QFT 后:\")\nprint(ps.StatePrint()(state))  # 恢复到 |1⟩",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## 总结\n\n- SparseState 只存储非零基态，基态数量随叠加增长\n- Hadamard 创建叠加态\n- 算术操作作用于每个基态（稀疏遍历）\n- SelfAdjointOperator 两次应用恢复原值，BaseOperator 用 dag() 撤销\n- QRAM 在叠加态下实现经典数据的批量查询\n- QFT / inverseQFT 用于相位估计类算法",
    "metadata": {}
   }
  ],

--- a/docs/sphinx/source/notebooks/03_算子示例.ipynb
+++ b/docs/sphinx/source/notebooks/03_算子示例.ipynb
@@ -298,7 +298,43 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Block Encoding：三对角矩阵\n\nBlock Encoding 将经典矩阵编码为酉矩阵，是量子线性代数算法的核心。下面的例子使用\n``pysparq.algorithms.block_encoding`` 中的 ``BlockEncodingTridiagonal`` 对三对角矩阵 :math:`A = \\alpha I + \\beta T` 进行块编码：\n\n```python\nfrom pysparq.algorithms.block_encoding import (\n    get_tridiagonal_matrix,\n    BlockEncodingTridiagonal,\n)\n\nalpha, beta, dim = 0.5, 0.3, 4\nA = get_tridiagonal_matrix(alpha, beta, dim)\nprint(f\"三对角矩阵 A:\\n{A}\")\n\n# 构建 Block Encoding 电路\nps.System.clear()\nps.System.add_register(\"main_reg\", ps.UnsignedInteger, 2)  # dim = 2^2\nps.System.add_register(\"anc_UA\", ps.UnsignedInteger, 4)\n\nstate = ps.SparseState()\nps.Init_Unsafe(\"main_reg\", 0)(state)\nps.Init_Unsafe(\"anc_UA\", 0)(state)\n\nblock_enc = BlockEncodingTridiagonal(\"main_reg\", \"anc_UA\", alpha, beta)\nblock_enc(state)\nprint(f\"Block Encoding 应用成功，基态数: {state.size()}\")\n\nblock_enc.dag(state)  # 释放辅助寄存器\nprint(f\"逆 Block Encoding 后，基态数: {state.size()}\")\n```\n\n电路结构：辅助寄存器准备 4 元素叠加态 → 主寄存器执行受控加/减 1 → 逆准备释放辅助寄存器。\n\n## Python 侧自定义算子\n\n当需要组合多个已有算子时，在 Python 侧直接封装：\n\n```python\nclass MyIncrement:\n    \"\"\"对寄存器值加 1（外置结果寄存器）。\"\"\"\n\n    def __init__(self, src: str, dst: str):\n        self.src = src\n        self.dst = dst\n\n    def __call__(self, state: ps.SparseState):\n        ps.Add_UInt_UInt(self.src, self.dst)(state)\n\n    def dag(self, state: ps.SparseState):\n        ps.Add_UInt_UInt(self.src, self.dst)(state)  # XOR 语义，加两次恢复\n\n\nps.System.clear()\nps.System.add_register(\"counter\", ps.UnsignedInteger, 4)\nps.System.add_register(\"result\", ps.UnsignedInteger, 4)\nstate = ps.SparseState()\nps.Init_Unsafe(\"counter\", 5)(state)\nps.Init_Unsafe(\"result\", 0)(state)\n\nmy_inc = MyIncrement(\"counter\", \"result\")\nmy_inc(state)          # result = 0 + 5 = 5\nmy_inc.dag(state)      # result = 5 + 5 = 0，恢复\n```\n\n如需新 primitives（超出已有算子表达能力），使用 ``compile_operator`` 将 C++ 代码编译为动态链接库：\n\n```python\nfrom pysparq.dynamic_operator import compile_operator\n\ncpp_code = '''\nclass FlipOp : public SelfAdjointOperator {\n    size_t reg_id;\npublic:\n    FlipOp(size_t r) : reg_id(r) {}\n    void operator()(std::vector<System>& state) const override {\n        for (auto& s : state) {\n            s.get(reg_id).value ^= 1;\n        }\n    }\n};\n'''\n\nFlipOp = compile_operator(\n    name=\"FlipOp\",\n    cpp_code=cpp_code,\n    base_class=\"SelfAdjointOperator\",\n    constructor_args=[(\"size_t\", \"reg_id\")],\n)\n\nps.System.clear()\nps.System.add_register(\"q\", ps.UnsignedInteger, 4)\nstate = ps.SparseState()\nps.Init_Unsafe(\"q\", 1)(state)\nflip = FlipOp(reg_id=0)\nflip(state)   # 第 0 比特翻转\n```\n\n## 总结\n\n本教程展示了：\n\n- 算术算子：Add, Mult, Compare\n- 量子门：X, Hadamard, Phase\n- QFT / inverseQFT\n- 条件操作\n- **Block Encoding**：用 ``BlockEncodingTridiagonal`` 对三对角矩阵进行块编码\n- **自定义算子**：Python 侧组合已有算子，或通过 ``compile_operator`` 编译 C++ 代码"
+   "source": "## Block Encoding：三对角矩阵\n\nBlock Encoding 将经典矩阵编码为酉矩阵，是量子线性代数算法的核心。下面的例子使用\n``pysparq.algorithms.block_encoding`` 中的 ``BlockEncodingTridiagonal`` 对三对角矩阵 :math:`A = \\alpha I + \\beta T` 进行块编码。"
+  },
+  {
+   "cell_type": "code",
+   "source": "from pysparq.algorithms.block_encoding import (\n    get_tridiagonal_matrix,\n    BlockEncodingTridiagonal,\n)\n\nalpha, beta, dim = 0.5, 0.3, 4\nA = get_tridiagonal_matrix(alpha, beta, dim)\nprint(f\"三对角矩阵 A:\\n{A}\")\n\n# 构建 Block Encoding 电路\nps.System.clear()\nps.System.add_register(\"main_reg\", ps.UnsignedInteger, 2)  # dim = 2^2\nps.System.add_register(\"anc_UA\", ps.UnsignedInteger, 4)\n\nstate = ps.SparseState()\nps.Init_Unsafe(\"main_reg\", 0)(state)\nps.Init_Unsafe(\"anc_UA\", 0)(state)\n\nblock_enc = BlockEncodingTridiagonal(\"main_reg\", \"anc_UA\", alpha, beta)\nblock_enc(state)\nprint(f\"Block Encoding 应用成功，基态数: {state.size()}\")\n\nblock_enc.dag(state)  # 释放辅助寄存器\nprint(f\"逆 Block Encoding 后，基态数: {state.size()}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## Python 侧自定义算子\n\n当需要组合多个已有算子时，在 Python 侧直接封装：",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "class MyIncrement:\n    \"\"\"对寄存器值加 1（外置结果寄存器）。\"\"\"\n\n    def __init__(self, src: str, dst: str):\n        self.src = src\n        self.dst = dst\n\n    def __call__(self, state: ps.SparseState):\n        ps.Add_UInt_UInt(self.src, self.dst)(state)\n\n    def dag(self, state: ps.SparseState):\n        ps.Add_UInt_UInt(self.src, self.dst)(state)  # XOR 语义，加两次恢复\n\n\nps.System.clear()\nps.System.add_register(\"counter\", ps.UnsignedInteger, 4)\nps.System.add_register(\"result\", ps.UnsignedInteger, 4)\nstate = ps.SparseState()\nps.Init_Unsafe(\"counter\", 5)(state)\nps.Init_Unsafe(\"result\", 0)(state)\n\nmy_inc = MyIncrement(\"counter\", \"result\")\nmy_inc(state)          # result = 0 + 5 = 5\nprint(f\"加法后 result = {state.basis_states[0].get(ps.System.get_id('result')).value}\")\nmy_inc.dag(state)      # result = 5 + 5 = 0，恢复\nprint(f\"dagger 后 result = {state.basis_states[0].get(ps.System.get_id('result')).value}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "如需新 primitives（超出已有算子表达能力），使用 ``compile_operator`` 将 C++ 代码编译为动态链接库：",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "from pysparq.dynamic_operator import compile_operator\n\ncpp_code = '''\nclass FlipOp : public SelfAdjointOperator {\n    size_t reg_id;\npublic:\n    FlipOp(size_t r) : reg_id(r) {}\n    void operator()(std::vector<System>& state) const override {\n        for (auto& s : state) {\n            s.get(reg_id).value ^= 1;\n        }\n    }\n};\n'''\n\nFlipOp = compile_operator(\n    name=\"FlipOp\",\n    cpp_code=cpp_code,\n    base_class=\"SelfAdjointOperator\",\n    constructor_args=[(\"size_t\", \"reg_id\")],\n)\n\nps.System.clear()\nps.System.add_register(\"q\", ps.UnsignedInteger, 4)\nstate = ps.SparseState()\nps.Init_Unsafe(\"q\", 1)(state)\nprint(\"初始:\", state.basis_states[0].get(ps.System.get_id(\"q\")).value)\nflip = FlipOp(reg_id=0)\nflip(state)   # 第 0 比特翻转\nprint(\"翻转后:\", state.basis_states[0].get(ps.System.get_id(\"q\")).value)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## 总结\n\n本教程展示了：\n\n- 算术算子：Add, Mult, Compare\n- 量子门：X, Hadamard, Phase\n- QFT / inverseQFT\n- 条件操作\n- **Block Encoding**：用 ``BlockEncodingTridiagonal`` 对三对角矩阵进行块编码\n- **自定义算子**：Python 侧组合已有算子，或通过 ``compile_operator`` 编译 C++ 代码",
+   "metadata": {}
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

- Fix `operators.html` → `operators.md` href in `docs/index.html` (deploy path mismatch caused broken "算子参考" link on GitHub Pages)
- Convert QRAM data loading and QFT sections in `02_稀疏态演化.ipynb` to executable cells with output
- Convert Block Encoding, Python custom operators, and `compile_operator` examples in `03_算子示例.ipynb` to executable cells with output

## Test plan

- [ ] CI passes (Docs job verifies notebooks execute without errors via nbsphinx)
- [ ] GitHub Pages `operators.md` link resolves correctly
- [ ] Notebook cells render with executed outputs in the Sphinx build

🤖 Generated with [Claude Code](https://claude.com/claude-code)