### PR TITLE
fix(docs): exclude 03_算子示例.ipynb from nbsphinx execution

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -228,11 +228,11 @@ jobs:
 
     - name: Install Documentation Dependencies
       run: |
-        pip install -r docs/sphinx/requirements.txt
+        "$pythonLocation/bin/python" -m pip install -r docs/sphinx/requirements.txt
         sudo apt-get update && sudo apt-get install -y doxygen graphviz pandoc libgomp1
 
     - name: Install pysparq for notebook execution
-      run: pip install --no-cache-dir .
+      run: "$pythonLocation/bin/python" -m pip install --no-cache-dir .
 
     - name: Generate Doxygen Documentation
       run: doxygen Doxyfile

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -45,12 +45,6 @@ exclude_patterns = [
     "_build",
     "Thumbs.db",
     ".DS_Store",
-    # Exclude 03_算子示例.ipynb from nbsphinx execution: the new live cells added in
-    # this notebook invoke pysparq operations that cause the Jupyter kernel to die
-    # (DeadKernelError) in the docs CI environment.  nbsphinx_allow_errors does not
-    # suppress kernel-death failures, so we exclude the notebook from the build
-    # entirely.  It is still present in the repo as a reference document.
-    "notebooks/03_算子示例.ipynb",
 ]
 
 # -- Options for HTML output -------------------------------------------------
@@ -162,3 +156,8 @@ nbsphinx_allow_errors = True   # Continue building docs even if a notebook cell 
 nbsphinx_timeout = 60
 # Note: nbsphinx prolog/epilog templates use env.docname instead of docname
 # in newer versions. We omit prolog for simplicity.
+# Skip execution for 03_算子示例.ipynb: the new live cells trigger compile_operator
+# (runtime C++ compilation), which causes the Jupyter kernel to die (DeadKernelError)
+# in the docs CI environment.  nbsphinx_allow_errors does not suppress kernel-death
+# failures.  The notebook is still rendered as static content.
+nbsphinx_exclude_patterns = ["notebooks/03_算子示例.ipynb"]

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -41,7 +41,17 @@ extensions = [
 ]
 
 templates_path = ["_templates"]
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = [
+    "_build",
+    "Thumbs.db",
+    ".DS_Store",
+    # Exclude 03_算子示例.ipynb from nbsphinx execution: the new live cells added in
+    # this notebook invoke pysparq operations that cause the Jupyter kernel to die
+    # (DeadKernelError) in the docs CI environment.  nbsphinx_allow_errors does not
+    # suppress kernel-death failures, so we exclude the notebook from the build
+    # entirely.  It is still present in the repo as a reference document.
+    "notebooks/03_算子示例.ipynb",
+]
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/sphinx/source/notebooks/03_算子示例.ipynb
+++ b/docs/sphinx/source/notebooks/03_算子示例.ipynb
@@ -321,19 +321,23 @@
   },
   {
    "cell_type": "markdown",
-   "source": "如需新 primitives（超出已有算子表达能力），使用 ``compile_operator`` 将 C++ 代码编译为动态链接库：",
+   "source": [
+    "如需新 primitives（超出已有算子表达能力），使用 ``compile_operator`` 将 C++ 代码编译为动态链接库：\n\n\n:::{warning}\n``compile_operator`` 目前存在已知问题（[#67](https://github.com/IAI-USTC-Quantum/QRAM-Simulator/issues/67)）：将编译后的算子作用于 ``SparseState`` 时会触发段错误。该问题正在修复中，当前代码展示仅供参考。\n:::\n\n"
+   ],
    "metadata": {}
   },
   {
    "cell_type": "code",
-   "source": "from pysparq.dynamic_operator import compile_operator\n\ncpp_code = '''\nclass FlipOp : public SelfAdjointOperator {\n    size_t reg_id;\npublic:\n    FlipOp(size_t r) : reg_id(r) {}\n    void operator()(std::vector<System>& state) const override {\n        for (auto& s : state) {\n            s.get(reg_id).value ^= 1;\n        }\n    }\n};\n'''\n\nFlipOp = compile_operator(\n    name=\"FlipOp\",\n    cpp_code=cpp_code,\n    base_class=\"SelfAdjointOperator\",\n    constructor_args=[(\"size_t\", \"reg_id\")],\n)\n\nps.System.clear()\nps.System.add_register(\"q\", ps.UnsignedInteger, 4)\nstate = ps.SparseState()\nps.Init_Unsafe(\"q\", 1)(state)\nprint(\"初始:\", state.basis_states[0].get(ps.System.get_id(\"q\")).value)\nflip = FlipOp(reg_id=0)\nflip(state)   # 第 0 比特翻转\nprint(\"翻转后:\", state.basis_states[0].get(ps.System.get_id(\"q\")).value)",
+   "source": "# WARNING: Known issue [#67](https://github.com/IAI-USTC-Quantum/QRAM-Simulator/issues/67) -\n# calling the compiled operator on SparseState currently segfaults.\n# This cell is excluded from nbsphinx execution and shown for reference only.\n\nfrom pysparq.dynamic_operator import compile_operator\n\ncpp_code = '''\nclass FlipOp : public SelfAdjointOperator {\n    size_t reg_id;\npublic:\n    FlipOp(size_t r) : reg_id(r) {}\n    void operator()(std::vector<System>& state) const override {\n        for (auto& s : state) {\n            s.get(reg_id).value ^= 1;\n        }\n    }\n};\n'''\n\nFlipOp = compile_operator(\n    name=\"FlipOp\",\n    cpp_code=cpp_code,\n    base_class=\"SelfAdjointOperator\",\n    constructor_args=[(\"size_t\", \"reg_id\")],\n)\n\nps.System.clear()\nps.System.add_register(\"q\", ps.UnsignedInteger, 4)\nstate = ps.SparseState()\nps.Init_Unsafe(\"q\", 1)(state)\nprint(\"初始:\", state.basis_states[0].get(ps.System.get_id(\"q\")).value)\nflip = FlipOp(reg_id=0)\nflip(state)   # 第 0 比特翻转\nprint(\"翻转后:\", state.basis_states[0].get(ps.System.get_id(\"q\")).value)",
    "metadata": {},
    "execution_count": null,
    "outputs": []
   },
   {
    "cell_type": "markdown",
-   "source": "## 总结\n\n本教程展示了：\n\n- 算术算子：Add, Mult, Compare\n- 量子门：X, Hadamard, Phase\n- QFT / inverseQFT\n- 条件操作\n- **Block Encoding**：用 ``BlockEncodingTridiagonal`` 对三对角矩阵进行块编码\n- **自定义算子**：Python 侧组合已有算子，或通过 ``compile_operator`` 编译 C++ 代码",
+   "source": [
+    "## 总结\n\n本教程展示了：\n\n- 算术算子：Add, Mult, Compare\n- 量子门：X, Hadamard, Phase\n- QFT / inverseQFT\n- 条件操作\n- **Block Encoding**：用 ``BlockEncodingTridiagonal`` 对三对角矩阵进行块编码\n- **自定义算子**：Python 侧组合已有算子，或通过 ``compile_operator`` 编译 C++ 代码（存在已知问题，见 [#67](https://github.com/IAI-USTC-Quantum/QRAM-Simulator/issues/67)）"
+   ],
    "metadata": {}
   }
  ],


### PR DESCRIPTION
## Summary
- Exclude `03_算子示例.ipynb` from nbsphinx execution in docs build
- The notebook's new live cells cause the Jupyter kernel to die (DeadKernelError) in the docs CI environment
- `nbsphinx_allow_errors = True` suppresses cell-level errors but not kernel-death failures

## Test plan
- [x] Docs CI passes on this PR
- [ ] Manual verification of docs build

Generated with Claude Code