### PR TITLE
fix(ci): escape dollar sign in workflow YAML

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -221,18 +221,20 @@ jobs:
       with:
         submodules: 'true'
 
-    - name: Setup Python
+    - id: setup-python
+      name: Setup Python
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
 
     - name: Install Documentation Dependencies
       run: |
-        "$pythonLocation/bin/python" -m pip install -r docs/sphinx/requirements.txt
+        "${{ env.pythonLocation }}/bin/python" -m pip install -r docs/sphinx/requirements.txt
         sudo apt-get update && sudo apt-get install -y doxygen graphviz pandoc libgomp1
 
     - name: Install pysparq for notebook execution
-      run: "$pythonLocation/bin/python" -m pip install --no-cache-dir .
+      run: |
+        "${{ env.pythonLocation }}/bin/python" -m pip install --no-cache-dir .
 
     - name: Generate Doxygen Documentation
       run: doxygen Doxyfile


### PR DESCRIPTION
## Summary

The `cmake-multi-platform.yml` workflow fails at validation time (0s) because `"$pythonLocation/bin/python"` in YAML double-quoted scalars is interpreted as a YAML variable reference (YAML 1.1 behavior), causing:

```
expected <block end>, but found '<scalar>'
  in line 235: run: "$pythonLocation/bin/python" -m pip install --no-cache-dir .
```

Fix:
1. Add `id: setup-python` to the docs job's setup-python step
2. Use `\${{ env.pythonLocation }}` (backslash-escaped dollar sign, so YAML treats it as literal `$`, plus GitHub Actions expression syntax)

## Test plan

- [ ] CI passes on this PR

Generated with Claude Code