### PR TITLE
fix: System::get_register_info segfault, QRAM numpy array, address_size

### DIFF
--- a/PySparQ/core.cpp
+++ b/PySparQ/core.cpp
@@ -428,7 +428,15 @@ Args:
     py::class_<qram_qutrit::QRAMCircuit>(m, "QRAMCircuit_qutrit")
         .def(py::init<size_t, size_t>(), py::arg("addr_size"), py::arg("data_size"))
         .def(py::init<size_t, size_t, const memory_t &>(), py::arg("addr_size"), py::arg("data_size"), py::arg("memory"))
-        .def(py::init<size_t, size_t, memory_t &&>(), py::arg("addr_size"), py::arg("data_size"), py::arg("memory"));
+        .def(py::init<size_t, size_t, memory_t &&>(), py::arg("addr_size"), py::arg("data_size"), py::arg("memory"))
+        .def(py::init([](size_t addr_size, size_t data_size, py::array_t<uint64_t, py::array::c_style | py::array::forcecast> np_arr)
+                      {
+                          const uint64_t *ptr = np_arr.data();
+                          memory_t mem(ptr, ptr + np_arr.size());
+                          return new qram_qutrit::QRAMCircuit(addr_size, data_size, std::move(mem));
+                      }),
+             py::arg("addr_size"), py::arg("data_size"), py::arg("memory"))
+        .def_readonly("address_size", &qram_qutrit::QRAMCircuit::address_size);
 
     // 绑定QRAMLoad
     BIND_SELF_ADJOINT_OPERATOR(QRAMLoad, R"doc(

--- a/SparQ/src/basic_components.cpp
+++ b/SparQ/src/basic_components.cpp
@@ -235,6 +235,9 @@ namespace qram_simulator
 			}
 		);
 
+		if (iter == name_register_map.rend())
+			throw_general_runtime_error("Register not found.");
+
 		return *iter;
 	}
 


### PR DESCRIPTION
Closes #68, #69, #70, #71

## Summary
- **#68** `SparQ`: add bounds check in `System::get_register_info(string_view)` — throws `RuntimeError` instead of dereferencing `end()` iterator on missing register
- **#69** `PySparQ`: add `py::array_t<uint64_t>` constructor overload to `QRAMCircuit_qutrit` so `numpy.ndarray` memory is accepted directly (fixes `mat.data` in `cks_solver`)
- **#70** `PySparQ`: expose `address_size` as `def_readonly` property on `QRAMCircuit_qutrit`
- **#71**: already implemented — `CondRot_General_Bool(reg_in, reg_out, angle_function)` 3-arg form was already exported and working

## Test plan
- [x] All 63 C++ unit tests pass
- [x] Python verification: `ps.System.size_of("nonexistent")` raises `RuntimeError`
- [x] Python verification: `ps.QRAMCircuit_qutrit(2, 2, np.array([...], dtype=np.uint64))` works
- [x] Python verification: `ps.QRAMCircuit_qutrit(3, 4).address_size` returns `3`
- [x] Python verification: `ps.CondRot_General_Bool('cond', 'target', my_func)` works (3-arg form)

🤖 Generated with [Claude Code](https://claude.com/claude-code)