### PR TITLE
fix(cibuildwheel): remove unsupported after-build hook on linux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ skip = ["*-musllinux_*", "*-win32", "*-macos*"]
 archs = ["x86_64"]
 before-all = "yum install -y libgomp"
 before-build = "bash {project}/.cibuildwheel-hooks/pre-hook.sh"
-after-build = "bash {project}/.cibuildwheel-hooks/post-hook.sh"
 
 [tool.cibuildwheel.windows]
 archs = ["AMD64"]


### PR DESCRIPTION
## Summary

cibuildwheel 2.x removed support for `after-build` on Linux builds. This caused the `v0.1.1` PyPI publish to fail on ubuntu-latest.

```
cibuildwheel: Option 'after-build' not supported in the 'linux' section
```

**Fix:** Remove the `after-build` hook from `pyproject.toml` linux section.

## Test plan

- [x] CI build on this PR passes

## After merge

After this PR merges, the `v0.1.1` tag should be retagged on the new `main`:

```bash
git fetch upstream && git tag -d v0.1.1 && git tag -a v0.1.1 -m "Release v0.1.1: CKS/QDA Python Primitive Alignment" upstream/main && git push upstream v0.1.1 --force
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)